### PR TITLE
Support for optionally serving /_status endpoint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ matrix:
   fast_finish: true
 
 go:
-  - 1.3
-  - 1.4
   - 1.5
 
 before_install:

--- a/main.go
+++ b/main.go
@@ -35,18 +35,18 @@ import (
 )
 
 var (
-	listenAddress  = kingpin.Flag("listen", "Address and port to listen on.").PlaceHolder("ADDR").Required().TCP()
+	listenAddress  = kingpin.Flag("listen", "Address and port to listen on (HOST:PORT).").PlaceHolder("ADDR").Required().TCP()
 	forwardAddress = kingpin.Flag("target", "Address to foward connections to (HOST:PORT, or unix:PATH).").PlaceHolder("ADDR").Required().String()
 	unsafeTarget   = kingpin.Flag("unsafe-target", "If set, does not limit target to localhost, 127.0.0.1 or ::1").Bool()
 	keystorePath   = kingpin.Flag("keystore", "Path to certificate and keystore (PKCS12).").PlaceHolder("PATH").Required().String()
-	keystorePass   = kingpin.Flag("storepass", "Password for certificate and keystore.").PlaceHolder("PASS").String()
+	keystorePass   = kingpin.Flag("storepass", "Password for certificate and keystore (optional).").PlaceHolder("PASS").String()
 	caBundlePath   = kingpin.Flag("cacert", "Path to certificate authority bundle file (PEM/X509).").Required().String()
 	timedReload    = kingpin.Flag("timed-reload", "Reload keystores every N seconds, refresh listener on changes.").PlaceHolder("N").Int()
 	allowAll       = kingpin.Flag("allow-all", "Allow all clients, do not check client cert subject.").Bool()
 	allowedCNs     = kingpin.Flag("allow-cn", "Allow clients with given common name (can be repeated).").PlaceHolder("CN").Strings()
 	allowedOUs     = kingpin.Flag("allow-ou", "Allow clients with organizational unit name (can be repeated).").PlaceHolder("OU").Strings()
-	statusAddress  = kingpin.Flag("status", "Enable serving /_status endpoint on given addr:port (optional)").PlaceHolder("ADDR").TCP()
-	enableProf     = kingpin.Flag("pprof", "Enable serving /debug/pprof endpoints alongside /_status (for profiling)").Bool()
+	statusAddress  = kingpin.Flag("status", "Enable serving /_status on given HOST:PORT (shows tunnel and backend health status).").PlaceHolder("ADDR").TCP()
+	enableProf     = kingpin.Flag("pprof", "Enable serving /debug/pprof endpoints alongside /_status (for profiling).").Bool()
 	useSyslog      = kingpin.Flag("syslog", "Send logs to syslog instead of stderr.").Bool()
 )
 

--- a/status.go
+++ b/status.go
@@ -1,0 +1,110 @@
+/*-
+ * Copyright 2015 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+)
+
+type StatusHandler struct {
+	// Mutex for locking
+	mu *sync.Mutex
+	// Backend dialer to check if target is up and running
+	dial func() (net.Conn, error)
+	// Current status
+	listening bool
+	reloading bool
+}
+
+type StatusResponse struct {
+	Ok            bool      `json:"ok"`
+	Status        string    `json:"status"`
+	BackendOk     bool      `json:"backend_ok"`
+	BackendStatus string    `json:"backend_status"`
+	BackendError  string    `json:"backend_error,omitempty"`
+	Time          time.Time `json:"time"`
+	Hostname      string    `json:"hostname,omitempty"`
+	Message       string    `json:"message,omitempty"`
+}
+
+func NewStatusHandler(dial func() (net.Conn, error)) *StatusHandler {
+	return &StatusHandler{&sync.Mutex{}, dial, false, false}
+}
+
+func (s *StatusHandler) Listening() {
+	s.mu.Lock()
+	s.listening = true
+	s.reloading = false
+	s.mu.Unlock()
+}
+
+func (s *StatusHandler) Reloading() {
+	s.mu.Lock()
+	s.reloading = true
+	s.mu.Unlock()
+}
+
+func (s *StatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	resp := StatusResponse{
+		Time: time.Now(),
+	}
+
+	conn, err := s.dial()
+	resp.BackendOk = err == nil
+
+	if resp.BackendOk {
+		defer conn.Close()
+		resp.BackendStatus = "ok"
+	} else {
+		resp.BackendError = err.Error()
+		resp.BackendStatus = "critical"
+	}
+
+	s.mu.Lock()
+	resp.Ok = s.listening && resp.BackendOk
+	if !s.listening {
+		resp.Message = "initializing"
+	} else if s.reloading {
+		resp.Message = "reloading"
+	} else {
+		resp.Message = "listening"
+	}
+	s.mu.Unlock()
+
+	if resp.Ok && resp.BackendOk {
+		resp.Status = "ok"
+	} else {
+		resp.Status = "critical"
+	}
+
+	hostname, err := os.Hostname()
+	if err == nil {
+		resp.Hostname = hostname
+	}
+
+	out, err := json.Marshal(resp)
+	if err != nil {
+		panic(err)
+	}
+
+	w.Write(out)
+}


### PR DESCRIPTION
r: @alokmenghrajani @mcpherrinm @sqshh 

Support for optionally serving /_status endpoint. Closes #23.

Example response from status handler:
```
{"ok":false,"status":"critical","backend_ok":false,"backend_status":"critical","backend_error":"dial tcp4 127.0.0.1:8080: getsockopt: connection refused",message:"listening","time":"2015-12-15T19:52:17.050538029-08:00","hostname":"cs.local"}
```