### PR TITLE
Status improvements

### DIFF
--- a/status.go
+++ b/status.go
@@ -110,5 +110,9 @@ func (s *statusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		panic(err)
 	}
 
+	if !resp.Ok {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}
+
 	w.Write(out)
 }


### PR DESCRIPTION
* Make status port listen on localhost only
* Use SO_REUSEPORT to allow co-existent tunnels (for in-place upgrades)
* Return 503 on /_status if tunnel down (see https://github.com/square/p2/wiki/Health-Checks)