### PR TITLE
Use jbenet/go-reuseport instead of kavu/go_reuseport

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/kavu/go_reuseport"
+	"github.com/jbenet/go-reuseport"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
@@ -144,7 +144,7 @@ func main() {
 			mux.Handle("/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
 		}
 
-		listener, err := reuseport.NewReusablePortListener("tcp4", fmt.Sprintf("localhost:%d", *statusPort))
+		listener, err := reuseport.Listen("tcp", fmt.Sprintf("localhost:%d", *statusPort))
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error: unable to bind on status port: %s", err)
 			os.Exit(1)
@@ -211,8 +211,8 @@ func validateTarget(addr string) bool {
 // expiring.
 func listen(started chan bool, context *Context) {
 	// Open raw listening socket
-	network, address := decodeAddress(*listenAddress)
-	rawListener, err := reuseport.NewReusablePortListener(network, address)
+	network, address := (*listenAddress).Network(), (*listenAddress).String()
+	rawListener, err := reuseport.Listen(network, address)
 	if err != nil {
 		logger.Printf("error opening socket: %s", err)
 		started <- false

--- a/net.go
+++ b/net.go
@@ -117,21 +117,6 @@ func copyData(dst net.Conn, src net.Conn) {
 	}
 }
 
-// Helper function to decode a *net.TCPAddr into a tuple of network and
-// address. Must use this since kavu/so_reuseport does not currently
-// support passing "tcp" to support for IPv4 and IPv6. We must pass "tcp4"
-// or "tcp6" explicitly.
-func decodeAddress(tuple *net.TCPAddr) (network, address string) {
-	if tuple.IP.To4() != nil {
-		network = "tcp4"
-	} else {
-		network = "tcp6"
-	}
-
-	address = tuple.String()
-	return
-}
-
 // Parse a string representing a TCP address or UNIX socket for our backend
 // target. The input can be or the form "HOST:PORT" for TCP or "unix:PATH"
 // for a UNIX socket.
@@ -149,6 +134,6 @@ func parseTarget(input string) (network, address string, err error) {
 		return
 	}
 
-	network, address = decodeAddress(tcp)
+	network, address = tcp.Network(), tcp.String()
 	return
 }


### PR DESCRIPTION
Use jbenet/go-reuseport instead of kavu/go_reuseport, supports "tcp" as protocol.