### PR TITLE
Avoid tls.Config object copy (has embedded lock)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ go:
   - 1.5
   - tip
 
+before_script:
+  - go vet ./...
+
 before_install:
   - python --version
   - openssl version


### PR DESCRIPTION
Avoid tls.Config object copy (has embedded lock)

Fixes go vet error:

```
cs ghostunnel master $ go vet ./...
main.go:266: serveStatus passes Lock by value: crypto/tls.Config contains sync.Once contains sync.Mutex
exit status 1
```