### PR TITLE
Dockerfile for redis with ghostunnel

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Verify that the client(s) can connect with their client certificate:
 If `openssl s_client` can connect, then the tunnel should be working as
 intended! Be sure to check the logs to see incoming connections and other
 information. Note that by default ghostunnel logs to stderr and runs in the
-foreground.  For deamonization, we recommend using a utility such as
-[daemonize](http://software.clapper.org/daemonize/). If you prefer, ghostunnel
-also supports logging to syslog with the `--syslog` flag.
+foreground (set `--syslog` to log to syslog). For deamonization, we recommend
+using a utility such as [daemonize](http://software.clapper.org/daemonize/).
+For an example on how to use ghostunnel in a Docker container, see the `docker`
+subdirectory.

--- a/docker/redis-tls/Dockerfile
+++ b/docker/redis-tls/Dockerfile
@@ -44,17 +44,23 @@ RUN \
   sed -i 's/^\(bind .*\)$/# \1/' /etc/redis/redis.conf && \
   sed -i 's/^\(daemonize .*\)$/# \1/' /etc/redis/redis.conf && \
   sed -i 's/^\(dir .*\)$/# \1\ndir \/data/' /etc/redis/redis.conf && \
-  sed -i 's/^\(logfile .*\)$/# \1/' /etc/redis/redis.conf
+  sed -i 's/^\(logfile .*\)$/# \1/' /etc/redis/redis.conf && \
+  sed -i 's/^\(port .*\)$/# \1/' /etc/redis/redis.conf
 
 # Configure redis to listen on UNIX socket.
 RUN echo "port 0" >> /etc/redis/redis.conf
 RUN echo "unixsocket /tmp/redis.sock" >> /etc/redis/redis.conf
 RUN echo "unixsocketperm 700" >> /etc/redis/redis.conf
 
+RUN useradd -ms /bin/false redis
+
 # Install ghostunnel.
 RUN mkdir /ghostunnel
 COPY run.sh /ghostunnel/run.sh
 RUN go get github.com/square/ghostunnel
+
+# Install sudo.
+RUN apt-get update && apt-get install -y sudo --no-install-recommends
 
 # Define mountable directories.
 VOLUME ["/data"]

--- a/docker/redis-tls/Dockerfile
+++ b/docker/redis-tls/Dockerfile
@@ -51,7 +51,6 @@ RUN \
 RUN echo "port 0" >> /etc/redis/redis.conf
 RUN echo "unixsocket /tmp/redis.sock" >> /etc/redis/redis.conf
 RUN echo "unixsocketperm 700" >> /etc/redis/redis.conf
-
 RUN useradd -ms /bin/false redis
 
 # Install ghostunnel.
@@ -59,14 +58,15 @@ RUN mkdir /ghostunnel
 COPY run.sh /ghostunnel/run.sh
 RUN go get github.com/square/ghostunnel
 
-# Install sudo.
-RUN apt-get update && apt-get install -y sudo --no-install-recommends
-
 # Define mountable directories.
+RUN mkdir -p /data && chown -R redis:redis /data
 VOLUME ["/data"]
 
 # Define working directory.
 WORKDIR /data
+
+# Drop privs to non-root
+USER redis
 
 # Define default command.
 ENTRYPOINT ["/ghostunnel/run.sh"]

--- a/docker/redis-tls/Dockerfile
+++ b/docker/redis-tls/Dockerfile
@@ -1,0 +1,69 @@
+# Dockerfile for redis with ghostunnel as SSL/TLS proxy.
+#
+# This is a fork of dockerfile/redis, licensed under:
+# -----------------------------------------------------------------------------
+# The MIT License (MIT)
+# 
+# Copyright (c) Dockerfile Project
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+# -----------------------------------------------------------------------------
+
+FROM golang 
+
+MAINTAINER Cedric Staub "cs@squareup.com"
+
+# Install redis.
+RUN \
+  cd /tmp && \
+  wget http://download.redis.io/redis-stable.tar.gz && \
+  tar xvzf redis-stable.tar.gz && \
+  cd redis-stable && \
+  make && \
+  make install && \
+  cp -f src/redis-sentinel /usr/local/bin && \
+  mkdir -p /etc/redis && \
+  cp -f *.conf /etc/redis && \
+  rm -rf /tmp/redis-stable* && \
+  sed -i 's/^\(bind .*\)$/# \1/' /etc/redis/redis.conf && \
+  sed -i 's/^\(daemonize .*\)$/# \1/' /etc/redis/redis.conf && \
+  sed -i 's/^\(dir .*\)$/# \1\ndir \/data/' /etc/redis/redis.conf && \
+  sed -i 's/^\(logfile .*\)$/# \1/' /etc/redis/redis.conf
+
+# Configure redis to listen on UNIX socket.
+RUN echo "port 0" >> /etc/redis/redis.conf
+RUN echo "unixsocket /tmp/redis.sock" >> /etc/redis/redis.conf
+RUN echo "unixsocketperm 700" >> /etc/redis/redis.conf
+
+# Install ghostunnel.
+RUN mkdir /ghostunnel
+COPY run.sh /ghostunnel/run.sh
+RUN go get github.com/square/ghostunnel
+
+# Define mountable directories.
+VOLUME ["/data"]
+
+# Define working directory.
+WORKDIR /data
+
+# Define default command.
+ENTRYPOINT ["/ghostunnel/run.sh"]
+
+# Expose ports.
+EXPOSE 6379

--- a/docker/redis-tls/README.md
+++ b/docker/redis-tls/README.md
@@ -3,7 +3,7 @@ Redis with ghostunnel
 
 This directory contains a Dockerfile for building a Docker container that
 runs redis with ghostunnel as a SSL/TLS proxy. It serves as an example for how
-use ghostunnel to proxy connections to applications that do not natively
+to use ghostunnel to proxy connections to applications that do not natively
 support SSL/TLS.
 
 ### Building

--- a/docker/redis-tls/README.md
+++ b/docker/redis-tls/README.md
@@ -1,0 +1,32 @@
+Redis with ghostunnel
+=====================
+
+This directory contains a Dockerfile for building a Docker container that
+runs redis with ghostunnel as a SSL/TLS proxy. It serves as an example for how
+use ghostunnel to proxy connections to applications that do not natively
+support SSL/TLS.
+
+### Building
+
+To build the container:
+
+    docker build -t redis-tls .
+
+### Running 
+
+In this example, we assume that the $SECRETS_PATH directory contains your
+keystore and root certificate for the ghostunnel instance, and that the CN of
+clients you want to allow is `client`.
+
+To launch the container in the foreground:
+
+    docker run \
+      --name redis-tls \
+      -p 6379:6379 \
+      -v $SECRETS_PATH:/secrets \
+      redis-tls \
+      --keystore=/secrets/server-keystore.p12 \
+      --cacert=/secrets/ca-bundle.crt \
+      --allow-cn client
+
+See also https://github.com/dockerfile/redis

--- a/docker/redis-tls/README.md
+++ b/docker/redis-tls/README.md
@@ -14,7 +14,7 @@ To build the container:
 
 ### Running 
 
-In this example, we assume that the $SECRETS_PATH directory contains your
+In this example, we assume that the `$SECRETS_PATH` directory contains your
 keystore and root certificate for the ghostunnel instance, and that the CN of
 clients you want to allow is `client`.
 

--- a/docker/redis-tls/run.sh
+++ b/docker/redis-tls/run.sh
@@ -1,14 +1,22 @@
 #!/bin/sh
 
-REDIS_USER=redis
 REDIS_SOCKET=/tmp/redis.sock
+
+# Launch redis
+redis-server /etc/redis/redis.conf &
+
+while ! [ -S $REDIS_SOCKET ]; do
+  echo "Waiting for $REDIS_SOCKET to appear..."
+  sleep 1
+done
 
 # Launch ghostunnel
 # Terminate redis if tunnel shuts down
 (
-  sudo -u $REDIS_USER /go/bin/ghostunnel --listen 0.0.0.0:6379 --target unix:$REDIS_SOCKET "$@"
+  /go/bin/ghostunnel --listen 0.0.0.0:6379 --target unix:$REDIS_SOCKET "$@"
   redis-cli -s $REDIS_SOCKET shutdown
 ) &
 
-# Launch redis
-sudo -u $REDIS_USER redis-server /etc/redis/redis.conf
+# Wait for redis; terminate tunnel if redis stops
+wait %1
+killall ghostunnel

--- a/docker/redis-tls/run.sh
+++ b/docker/redis-tls/run.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+REDIS_SOCKET=/tmp/redis.sock
+
+# Launch ghostunnel
+# Terminate redis if tunnel shuts down
+(
+  /go/bin/ghostunnel --listen 0.0.0.0:6379 --target unix:$REDIS_SOCKET "$@"
+  redis-cli -s $REDIS_SOCKET shutdown
+) &
+
+# Launch redis
+redis-server /etc/redis/redis.conf

--- a/docker/redis-tls/run.sh
+++ b/docker/redis-tls/run.sh
@@ -1,13 +1,14 @@
 #!/bin/sh
 
+REDIS_USER=redis
 REDIS_SOCKET=/tmp/redis.sock
 
 # Launch ghostunnel
 # Terminate redis if tunnel shuts down
 (
-  /go/bin/ghostunnel --listen 0.0.0.0:6379 --target unix:$REDIS_SOCKET "$@"
+  sudo -u $REDIS_USER /go/bin/ghostunnel --listen 0.0.0.0:6379 --target unix:$REDIS_SOCKET "$@"
   redis-cli -s $REDIS_SOCKET shutdown
 ) &
 
 # Launch redis
-redis-server /etc/redis/redis.conf
+sudo -u $REDIS_USER redis-server /etc/redis/redis.conf


### PR DESCRIPTION
Dockerfile for redis with ghostunnel. Serves as an example for how to secure services that do not natively support SSL/TLS by fronting them with ghostunnel. 