### PR TITLE
Run tests with python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 
-sudo: false
+sudo: required
+dist: trusty
 
 env:
   - GO15VENDOREXPERIMENT=1

--- a/Makefile
+++ b/Makefile
@@ -39,5 +39,5 @@ integration: pre-integration $(INTEGRATION_TESTS)
 
 test-%:
 	@echo "=== RUN tests/$@"
-	@cd tests && python ./$@.py
+	@cd tests && ./$@.py
 	@echo "--- PASS: tests/$@"

--- a/tests/test-concurrent-connections.py
+++ b/tests/test-concurrent-connections.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python
+#!/usr/bin/env python3
 
 # Creates a ghostunnel. Ensures that multiple clients can communicate.
 

--- a/tests/test-handles-client-closes-connection.py
+++ b/tests/test-handles-client-closes-connection.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python
+#!/usr/bin/env python3
 
 # Creates a ghostunnel. Ensures when client disconnects that the server
 # connection also disconnects.

--- a/tests/test-handles-no-server.py
+++ b/tests/test-handles-no-server.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python
+#!/usr/bin/env python3
 
 # Creates a ghostunnel. Ensures that client gets a timeout if there is no
 # server.

--- a/tests/test-handles-server-closes-connection.py
+++ b/tests/test-handles-server-closes-connection.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python
+#!/usr/bin/env python3
 
 # Creates a ghostunnel. Ensures when server disconnects that the client
 # connection also disconnects.

--- a/tests/test-metrics-bridge.py
+++ b/tests/test-metrics-bridge.py
@@ -1,14 +1,14 @@
-#!/usr/local/bin/python
+#!/usr/bin/env python3
 
 # Creates a ghostunnel. Ensures that /_status endpoint works.
 
 from subprocess import Popen
 from test_common import create_root_cert, create_signed_cert, LOCALHOST, SocketPair, print_ok, cleanup_certs
-import urllib2, socket, ssl, time, os, signal, json, BaseHTTPServer, threading
+import urllib.request, urllib.error, urllib.parse, socket, ssl, time, os, signal, json, http.server, threading
 
 received_metrics = None
 
-class FakeMetricsBridgeHandler(BaseHTTPServer.BaseHTTPRequestHandler):
+class FakeMetricsBridgeHandler(http.server.BaseHTTPRequestHandler):
   def do_POST(self):
     global received_metrics
     print_ok("handling POST to fake bridge")
@@ -24,7 +24,7 @@ if __name__ == "__main__":
     create_signed_cert('new_server', 'root')
     create_signed_cert('client1', 'root')
 
-    httpd = BaseHTTPServer.HTTPServer(('localhost',13080), FakeMetricsBridgeHandler)
+    httpd = http.server.HTTPServer(('localhost',13080), FakeMetricsBridgeHandler)
     server = threading.Thread(target=httpd.handle_request)
     server.start()
 

--- a/tests/test-metrics-graphite.py
+++ b/tests/test-metrics-graphite.py
@@ -1,10 +1,10 @@
-#!/usr/local/bin/python
+#!/usr/bin/env python3
 
 # Creates a ghostunnel. Ensures that /_status endpoint works.
 
 from subprocess import Popen
 from test_common import create_root_cert, create_signed_cert, LOCALHOST, SocketPair, print_ok, cleanup_certs
-import urllib2, socket, ssl, time, os, signal, json, BaseHTTPServer, threading
+import urllib.request, urllib.error, urllib.parse, socket, ssl, time, os, signal, json, http.server, threading
 
 if __name__ == "__main__":
   ghostunnel = None

--- a/tests/test-rejects-invalid-ou-or-ca.py
+++ b/tests/test-rejects-invalid-ou-or-ca.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python
+#!/usr/bin/env python3
 
 # Creates a ghostunnel. Ensures client1 can connect but that clients with
 # ou=client2 or ca=other_root can't connect.

--- a/tests/test-reloads-certificate.py
+++ b/tests/test-reloads-certificate.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python
+#!/usr/bin/env python3
 
 # Creates a ghostunnel. Ensures that tunnel sees & reloads a certificate change.
 

--- a/tests/test-reloads-root-certificate.py
+++ b/tests/test-reloads-root-certificate.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python
+#!/usr/bin/env python3
 
 # Creates a ghostunnel. Ensures that tunnel sees & reloads a root certificate
 # change.

--- a/tests/test-status-port.py
+++ b/tests/test-status-port.py
@@ -1,10 +1,10 @@
-#!/usr/local/bin/python
+#!/usr/bin/env python3
 
 # Creates a ghostunnel. Ensures that /_status endpoint works.
 
 from subprocess import Popen
 from test_common import create_root_cert, create_signed_cert, LOCALHOST, SocketPair, print_ok, cleanup_certs
-import urllib2, socket, ssl, time, os, signal, json, sys
+import urllib.request, urllib.error, urllib.parse, socket, ssl, time, os, signal, json, sys
 
 if __name__ == "__main__":
   ghostunnel = None
@@ -22,15 +22,11 @@ if __name__ == "__main__":
       '--status=localhost:13100'])
     time.sleep(5)
 
-    # urrllib2.urlopen() needs Python >= 2.7.9 for cafile support...
-    if sys.version_info >= (2,7,9):
-        urlopen = lambda path: urllib2.urlopen(path, cafile='root.crt')
-    else:
-        urlopen = lambda path: urllib2.urlopen(path)
+    urlopen = lambda path: urllib.request.urlopen(path, cafile='root.crt')
 
     # Step 3: read status information
-    status = json.loads(urlopen("https://localhost:13100/_status").read())
-    metrics = json.loads(urlopen("https://localhost:13100/_metrics").read())
+    status = json.loads(str(urlopen("https://localhost:13100/_status").read(), 'utf-8'))
+    metrics = json.loads(str(urlopen("https://localhost:13100/_metrics").read(), 'utf-8'))
 
     if not status['ok']:
         raise Exception("ghostunnel reported non-ok status")
@@ -44,9 +40,8 @@ if __name__ == "__main__":
     time.sleep(10)
 
     # Step 3: read status information
-    # expecting tunnel to use "new_server" cert, setting cafile accordingly
-    status = json.loads(urlopen("https://localhost:13100/_status").read())
-    metrics = json.loads(urlopen("https://localhost:13100/_metrics").read())
+    status = json.loads(str(urlopen("https://localhost:13100/_status").read(), 'utf-8'))
+    metrics = json.loads(str(urlopen("https://localhost:13100/_metrics").read(), 'utf-8'))
 
     if not status['ok']:
         raise Exception("ghostunnel reported non-ok status")

--- a/tests/test-unix-socket-backend.py
+++ b/tests/test-unix-socket-backend.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python
+#!/usr/bin/env python3
 
 # Creates a ghostunnel. Ensures when server disconnects that the client
 # connection also disconnects.

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,5 +1,5 @@
 from subprocess import call
-import SocketServer, threading, time, socket, ssl, os, base64, textwrap
+import socketserver, threading, time, socket, ssl, os, base64, textwrap
 
 FNULL = open(os.devnull, 'w')
 LOCALHOST = '127.0.0.1'
@@ -32,7 +32,7 @@ def cleanup_certs(names):
         pass
 
 def print_ok(msg):
-  print "\033[92m{0}\033[0m".format(msg)
+  print(("\033[92m{0}\033[0m".format(msg)))
 
 # This is whacky but works. This class represents a pair of sockets which
 # correspond to each end of the tunnel. The class lets you verify that sending
@@ -70,16 +70,18 @@ class SocketPair:
     print_ok(msg)
 
   def validate_can_send_from_client(self, string, msg):
-    self.client_sock.send(string)
-    data = self.server_sock.recv(len(string))
-    if data != string:
+    encoded = bytes(string, 'utf-8')
+    self.client_sock.send(encoded)
+    data = self.server_sock.recv(len(encoded))
+    if data != encoded:
       raise Exception("did not receive expected string")
     print_ok(msg)
 
   def validate_can_send_from_server(self, string, msg):
-    self.server_sock.send(string)
-    data = self.client_sock.recv(len(string))
-    if data != string:
+    encoded = bytes(string, 'utf-8')
+    self.server_sock.send(encoded)
+    data = self.client_sock.recv(len(encoded))
+    if data != encoded:
       raise Exception("did not receive expected string")
     print_ok(msg)
 


### PR DESCRIPTION
r: @alokmenghrajani 
Runs tests with Python 3 (using Travis-CI's "Trusty Tahr" image). This will make it possible to properly test the --min-tls flag in our integration tests (since we get TLS 1.2 support).