### PR TITLE
Split dockerfiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,14 @@ language: go
 sudo: required
 dist: trusty
 
+services:
+  - docker
+
 env:
   - GO15VENDOREXPERIMENT=1
 
-matrix:
-  fast_finish: true
-  allow_failures:
-    - go: tip
-
 go:
-  - 1.5
   - 1.6
-  - tip
 
 before_install:
   - sudo `which pip3` install pyopenssl
@@ -23,6 +19,8 @@ before_install:
 
 install:
   - make build 
+  - docker build -t square/ghostunnel .
+  - docker build -t redis-tls docker/redis-tls
 
 before_script:
   - go vet .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Dockerfile for square/ghostunnel, useful as a basis for other images.
+#
+# To build this image:
+#     docker build -t square/ghostunnel .
+#
+# To run ghostunnel from the image (for example):
+#     docker run --rm square/ghostunnel ghostunnel --version
+#
+# For an example image that builds on top of this, check out the docker subdirectory.
+
+FROM golang:alpine
+
+MAINTAINER Cedric Staub "cs@squareup.com"
+
+# Install dependencies
+RUN apk add --update make git && go get github.com/Masterminds/glide
+
+# Build ghostunnel
+COPY . /go/src/ghostunnel
+RUN cd /go/src/ghostunnel && make build && cp ghostunnel /usr/bin && rm -rf /go/src/*

--- a/docker/redis-tls/Dockerfile
+++ b/docker/redis-tls/Dockerfile
@@ -1,5 +1,18 @@
 # Dockerfile for redis with ghostunnel as SSL/TLS proxy.
 #
+# To build this image:
+#     docker build -t redis-tls .
+#
+# To run, with given arguments to terminate TLS connections (for example):
+#     docker run \
+#       --name redis-tls \
+#       -p 6379:6379 \
+#       -v $SECRETS_PATH:/secrets \
+#       redis-tls \
+#       --keystore=/secrets/server-keystore.p12 \
+#       --cacert=/secrets/ca-bundle.crt \
+#       --allow-cn client
+#
 # This is a fork of dockerfile/redis, licensed under:
 # -----------------------------------------------------------------------------
 # The MIT License (MIT)
@@ -25,11 +38,14 @@
 # THE SOFTWARE.
 # -----------------------------------------------------------------------------
 
-FROM golang 
+FROM square/ghostunnel
 
 MAINTAINER Cedric Staub "cs@squareup.com"
 
-# Install redis.
+# Install dependencies for build
+RUN apk add --update make gcc libc-dev linux-headers
+
+# Download and compile redis
 RUN \
   cd /tmp && \
   wget http://download.redis.io/redis-stable.tar.gz && \
@@ -47,19 +63,17 @@ RUN \
   sed -i 's/^\(logfile .*\)$/# \1/' /etc/redis/redis.conf && \
   sed -i 's/^\(port .*\)$/# \1/' /etc/redis/redis.conf
 
-# Configure redis to listen on UNIX socket.
-RUN echo "port 0" >> /etc/redis/redis.conf
-RUN echo "unixsocket /tmp/redis.sock" >> /etc/redis/redis.conf
-RUN echo "unixsocketperm 700" >> /etc/redis/redis.conf
-RUN useradd -ms /bin/false redis
-
-# Install ghostunnel.
-RUN mkdir /ghostunnel
-COPY run.sh /ghostunnel/run.sh
-RUN go get github.com/square/ghostunnel
+# Configure redis, set up user
+RUN \
+  echo "port 0" >> /etc/redis/redis.conf && \
+  echo "unixsocket /tmp/redis.sock" >> /etc/redis/redis.conf && \
+  echo "unixsocketperm 700" >> /etc/redis/redis.conf && \
+  addgroup redis && \
+  adduser -S -s /bin/false redis && \
+  mkdir -p /data && \
+  chown -R redis:redis /data
 
 # Define mountable directories.
-RUN mkdir -p /data && chown -R redis:redis /data
 VOLUME ["/data"]
 
 # Define working directory.
@@ -69,7 +83,8 @@ WORKDIR /data
 USER redis
 
 # Define default command.
-ENTRYPOINT ["/ghostunnel/run.sh"]
+COPY entry.sh /entry.sh
+ENTRYPOINT ["/entry.sh"]
 
 # Expose ports.
 EXPOSE 6379

--- a/docker/redis-tls/Dockerfile
+++ b/docker/redis-tls/Dockerfile
@@ -12,66 +12,24 @@
 #       --keystore=/secrets/server-keystore.p12 \
 #       --cacert=/secrets/ca-bundle.crt \
 #       --allow-cn client
-#
-# This is a fork of dockerfile/redis, licensed under:
-# -----------------------------------------------------------------------------
-# The MIT License (MIT)
-# 
-# Copyright (c) Dockerfile Project
-# 
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-# 
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-# THE SOFTWARE.
-# -----------------------------------------------------------------------------
 
 FROM square/ghostunnel
 
 MAINTAINER Cedric Staub "cs@squareup.com"
 
-# Install dependencies for build
-RUN apk add --update make gcc libc-dev linux-headers
+# Install redis from alpine repositories
+RUN apk add --update redis
 
-# Download and compile redis
+# Configure redis to listen on UNIX socket
 RUN \
-  cd /tmp && \
-  wget http://download.redis.io/redis-stable.tar.gz && \
-  tar xvzf redis-stable.tar.gz && \
-  cd redis-stable && \
-  make && \
-  make install && \
-  cp -f src/redis-sentinel /usr/local/bin && \
-  mkdir -p /etc/redis && \
-  cp -f *.conf /etc/redis && \
-  rm -rf /tmp/redis-stable* && \
-  sed -i 's/^\(bind .*\)$/# \1/' /etc/redis/redis.conf && \
-  sed -i 's/^\(daemonize .*\)$/# \1/' /etc/redis/redis.conf && \
-  sed -i 's/^\(dir .*\)$/# \1\ndir \/data/' /etc/redis/redis.conf && \
-  sed -i 's/^\(logfile .*\)$/# \1/' /etc/redis/redis.conf && \
-  sed -i 's/^\(port .*\)$/# \1/' /etc/redis/redis.conf
-
-# Configure redis, set up user
-RUN \
-  echo "port 0" >> /etc/redis/redis.conf && \
-  echo "unixsocket /tmp/redis.sock" >> /etc/redis/redis.conf && \
-  echo "unixsocketperm 700" >> /etc/redis/redis.conf && \
-  addgroup redis && \
-  adduser -S -s /bin/false redis && \
-  mkdir -p /data && \
-  chown -R redis:redis /data
+  sed -i 's/^\(bind .*\)$/# \1/' /etc/redis.conf && \
+  sed -i 's/^\(daemonize .*\)$/# \1/' /etc/redis.conf && \
+  sed -i 's/^\(dir .*\)$/dir \/data/' /etc/redis.conf && \
+  sed -i 's/^\(logfile .*\)$/# \1/' /etc/redis.conf && \
+  sed -i 's/^\(port .*\)$/port 0/' /etc/redis.conf && \
+  sed -i 's/^# \(unixsocket .*\)$/\1/' /etc/redis.conf && \
+  sed -i 's/^# \(unixsocketperm .*\)$/\1/' /etc/redis.conf && \
+  mkdir -p /data && chown -R redis:redis /data
 
 # Define mountable directories.
 VOLUME ["/data"]

--- a/docker/redis-tls/entry.sh
+++ b/docker/redis-tls/entry.sh
@@ -13,10 +13,10 @@ done
 # Launch ghostunnel
 # Terminate redis if tunnel shuts down
 (
-  /go/bin/ghostunnel --listen 0.0.0.0:6379 --target unix:$REDIS_SOCKET "$@"
+  ghostunnel --listen 0.0.0.0:6379 --target unix:$REDIS_SOCKET "$@"
   redis-cli -s $REDIS_SOCKET shutdown
 ) &
 
 # Wait for redis; terminate tunnel if redis stops
 wait %1
-killall ghostunnel
+kill %2

--- a/docker/redis-tls/entry.sh
+++ b/docker/redis-tls/entry.sh
@@ -1,9 +1,10 @@
 #!/bin/sh
 
-REDIS_SOCKET=/tmp/redis.sock
+REDIS_CONFIG='/etc/redis.conf'
+REDIS_SOCKET=`grep 'unixsocket .*' $REDIS_CONFIG | cut -d' ' -f2`
 
 # Launch redis
-redis-server /etc/redis/redis.conf &
+redis-server $REDIS_CONFIG &
 
 while ! [ -S $REDIS_SOCKET ]; do
   echo "Waiting for $REDIS_SOCKET to appear..."


### PR DESCRIPTION
@alokmenghrajani @mcpherrinm 

Changes:
* Split ghostunnel build into separate dockerfiles
* Simplify redis-tls dockerfile (install redis from alpine instead of tarball)
* Build docker images on travis-ci runs

Also dropped Go 1.5 and tip from build. We don't need to support Go 1.5 anymore, and Go tip is continuously broken anyway which makes it kinda useless. Speeds up the build.