### PR TITLE
Generate test coverage for integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,8 @@
 *.key
 *.pyc
 *.crt
+*.out
 vendor/
 ghostunnel
+ghostunnel.test
+__pycache__

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ go:
 before_install:
   - sudo `which pip3` install pyopenssl
   - go get github.com/Masterminds/glide
+  - go get github.com/axw/gocov/gocov
+  - go get github.com/mattn/goveralls
+  - go get golang.org/x/tools/cmd/cover
   - make depends
 
 install:
@@ -27,3 +30,8 @@ before_script:
 
 script:
   - make test
+
+after_success:
+  - gocov convert *.out */*.out > gocov.json
+  - $HOME/gopath/bin/goveralls -gocovdata gocov.json -service=travis-ci
+

--- a/Makefile
+++ b/Makefile
@@ -28,11 +28,13 @@ pre-unit:
 	@echo "*** Running unit tests ***"
 
 unit: pre-unit
-	go test -v
+	go test -v -covermode=set -coverprofile=coverage.out
 
 # Run integration tests
+# Builds test binary with integration test coverage
 pre-integration: 
 	@echo "*** Running integration tests ***"
+	go test -c -covermode=set -coverpkg .
 
 integration: pre-integration $(INTEGRATION_TESTS)
 	@echo "PASS"

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@ Ghostunnel
 ==========
 
 [![license](http://img.shields.io/badge/license-apache_2.0-red.svg?style=flat)](https://raw.githubusercontent.com/square/ghostunnel/master/LICENSE)
-[![build](https://img.shields.io/travis/square/ghostunnel/master.svg?style=flat)](https://travis-ci.org/square/ghostunnel)
-[![report](https://goreportcard.com/badge/github.com/square/ghostunnel)](https://goreportcard.com/report/github.com/square/ghostunnel)
+[![build](https://img.shields.io/travis/square/ghostunnel/master.svg?style=flat)](https://travis-ci.org/square/ghostunnel) [![coverage](https://coveralls.io/repos/github/square/ghostunnel/badge.svg?branch=cs%2Fcoverage)](https://coveralls.io/r/square/ghostunnel) [![report](https://goreportcard.com/badge/github.com/square/ghostunnel)](https://goreportcard.com/report/github.com/square/ghostunnel)
 
 👻
 

--- a/main.go
+++ b/main.go
@@ -156,12 +156,16 @@ func clientValidateFlags() error {
 }
 
 func main() {
+	run(os.Args[1:])
+}
+
+func run(args []string) {
 	initLogger()
 	runtime.GOMAXPROCS(runtime.NumCPU())
 
 	app.Version(fmt.Sprintf("rev %s built with %s", buildRevision, buildCompiler))
 	app.Validate(validateFlags)
-	command := kingpin.MustParse(app.Parse(os.Args[1:]))
+	command := kingpin.MustParse(app.Parse(args))
 
 	// metrics
 	if *graphiteAddr != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -17,10 +17,28 @@
 package main
 
 import (
+	"encoding/json"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestIntegrationMain(t *testing.T) {
+	// This function serves as an entry point for running integration tests.
+	// We're wrapping it in a test case so that we can record the test coverage.
+	isIntegration := os.Getenv("GHOSTUNNEL_INTEGRATION_TEST")
+
+	if isIntegration == "true" {
+		var wrappedArgs []string
+		err := json.Unmarshal([]byte(os.Getenv("GHOSTUNNEL_INTEGRATION_ARGS")), &wrappedArgs)
+		if err != nil {
+			panic(err)
+		}
+
+		run(wrappedArgs)
+	}
+}
 
 func TestAllowsLocalhost(t *testing.T) {
 	*serverUnsafeTarget = false

--- a/tests/test-client-concurrent-connections.py
+++ b/tests/test-client-concurrent-connections.py
@@ -4,7 +4,7 @@
 
 from subprocess import Popen
 from multiprocessing import Process
-from test_common import RootCert, LOCALHOST, STATUS_PORT, SocketPair, print_ok, TcpClient, TlsServer
+from test_common import *
 import socket, ssl, time, random
 
 def send_data(i, p):
@@ -37,7 +37,7 @@ if __name__ == "__main__":
       root.create_signed_cert("server{0}".format(i))
 
     # start ghostunnel
-    ghostunnel = Popen(['../ghostunnel', 'client', '--listen={0}:13004'.format(LOCALHOST),
+    ghostunnel = run_ghostunnel(['client', '--listen={0}:13004'.format(LOCALHOST),
       '--target={0}:13005'.format(LOCALHOST), '--keystore=client.p12',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
       '--cacert=root.crt'])
@@ -54,5 +54,4 @@ if __name__ == "__main__":
 
     print_ok("OK")
   finally:
-    if ghostunnel:
-      ghostunnel.kill()
+    terminate(ghostunnel)

--- a/tests/test-client-handles-client-closes-connection.py
+++ b/tests/test-client-handles-client-closes-connection.py
@@ -4,7 +4,7 @@
 # connection also disconnects.
 
 from subprocess import Popen
-from test_common import RootCert, LOCALHOST, STATUS_PORT, SocketPair, print_ok, TcpClient, TlsServer
+from test_common import *
 import socket, ssl
 
 if __name__ == "__main__":
@@ -16,7 +16,7 @@ if __name__ == "__main__":
     root.create_signed_cert('client')
 
     # start ghostunnel
-    ghostunnel = Popen(['../ghostunnel', 'client', '--listen={0}:13004'.format(LOCALHOST),
+    ghostunnel = run_ghostunnel(['client', '--listen={0}:13004'.format(LOCALHOST),
       '--target={0}:13005'.format(LOCALHOST), '--keystore=client.p12',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
       '--cacert=root.crt'])
@@ -29,5 +29,5 @@ if __name__ == "__main__":
 
     print_ok("OK")
   finally:
-    if ghostunnel:
-      ghostunnel.kill()
+    terminate(ghostunnel)
+      

--- a/tests/test-client-handles-no-server.py
+++ b/tests/test-client-handles-no-server.py
@@ -4,7 +4,7 @@
 # server.
 
 from subprocess import Popen
-from test_common import RootCert, LOCALHOST, STATUS_PORT, SocketPair, print_ok, TcpClient, TlsServer
+from test_common import *
 import socket, ssl
 
 if __name__ == "__main__":
@@ -16,7 +16,7 @@ if __name__ == "__main__":
     root.create_signed_cert('client')
 
     # start ghostunnel
-    ghostunnel = Popen(['../ghostunnel', 'client', '--listen={0}:13004'.format(LOCALHOST),
+    ghostunnel = run_ghostunnel(['client', '--listen={0}:13004'.format(LOCALHOST),
       '--target={0}:13005'.format(LOCALHOST), '--keystore=client.p12',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT), '--cacert=root.crt'])
 
@@ -29,7 +29,8 @@ if __name__ == "__main__":
 
     # client should connect
     pair = SocketPair(TcpClient(13004), TlsServer('server', 'root', 13005))
+    pair.cleanup()
     print_ok("OK")
   finally:
-    if ghostunnel:
-      ghostunnel.kill()
+    terminate(ghostunnel)
+      

--- a/tests/test-client-handles-server-closes-connection.py
+++ b/tests/test-client-handles-server-closes-connection.py
@@ -4,7 +4,7 @@
 # connection also disconnects.
 
 from subprocess import Popen
-from test_common import RootCert, LOCALHOST, STATUS_PORT, SocketPair, print_ok, TcpClient, TlsServer
+from test_common import *
 import socket, ssl
 
 if __name__ == "__main__":
@@ -16,7 +16,7 @@ if __name__ == "__main__":
     root.create_signed_cert('client')
 
     # start ghostunnel
-    ghostunnel = Popen(['../ghostunnel', 'client', '--listen={0}:13004'.format(LOCALHOST),
+    ghostunnel = run_ghostunnel(['client', '--listen={0}:13004'.format(LOCALHOST),
       '--target={0}:13005'.format(LOCALHOST), '--keystore=client.p12',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT), '--cacert=root.crt'])
 
@@ -28,5 +28,5 @@ if __name__ == "__main__":
 
     print_ok("OK")
   finally:
-    if ghostunnel:
-      ghostunnel.kill()
+    terminate(ghostunnel)
+      

--- a/tests/test-client-metrics-bridge.py
+++ b/tests/test-client-metrics-bridge.py
@@ -3,7 +3,7 @@
 # Creates a ghostunnel. Ensures that /_status endpoint works.
 
 from subprocess import Popen
-from test_common import RootCert, LOCALHOST, STATUS_PORT, print_ok
+from test_common import *
 import urllib.request, urllib.error, urllib.parse, socket, ssl, time, os, signal, json, http.server, threading
 
 received_metrics = None
@@ -27,7 +27,7 @@ if __name__ == "__main__":
     server.start()
 
     # start ghostunnel
-    ghostunnel = Popen(['../ghostunnel', 'client', '--listen={0}:13004'.format(LOCALHOST),
+    ghostunnel = run_ghostunnel(['client', '--listen={0}:13004'.format(LOCALHOST),
       '--target={0}:13005'.format(LOCALHOST), '--keystore=client.p12',
       '--cacert=root.crt',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
@@ -49,5 +49,5 @@ if __name__ == "__main__":
 
     print_ok("OK")
   finally:
-    if ghostunnel:
-      ghostunnel.kill()
+    terminate(ghostunnel)
+      

--- a/tests/test-client-metrics-graphite.py
+++ b/tests/test-client-metrics-graphite.py
@@ -3,7 +3,7 @@
 # Creates a ghostunnel. Ensures that /_status endpoint works.
 
 from subprocess import Popen
-from test_common import RootCert, LOCALHOST, STATUS_PORT, print_ok
+from test_common import *
 import urllib.request, urllib.error, urllib.parse, socket, ssl, time, os, signal, json, http.server, threading
 
 if __name__ == "__main__":
@@ -21,7 +21,7 @@ if __name__ == "__main__":
     m.listen(1)
 
     # start ghostunnel
-    ghostunnel = Popen(['../ghostunnel', 'client', '--listen={0}:13004'.format(LOCALHOST),
+    ghostunnel = run_ghostunnel(['client', '--listen={0}:13004'.format(LOCALHOST),
       '--target={0}:13005'.format(LOCALHOST), '--keystore=client.p12',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
       '--cacert=root.crt', '--graphite=localhost:13099'])
@@ -34,5 +34,5 @@ if __name__ == "__main__":
 
     print_ok("OK")
   finally:
-    if ghostunnel:
-      ghostunnel.kill()
+    terminate(ghostunnel)
+      

--- a/tests/test-client-override-server-name.py
+++ b/tests/test-client-override-server-name.py
@@ -4,7 +4,7 @@
 # not root2.
 
 from subprocess import Popen
-from test_common import RootCert, LOCALHOST, STATUS_PORT, SocketPair, print_ok, TcpClient, TlsServer
+from test_common import *
 import socket, ssl
 
 if __name__ == "__main__":
@@ -20,7 +20,7 @@ if __name__ == "__main__":
     other_root.create_signed_cert('other_server')
 
     # start ghostunnel
-    ghostunnel = Popen(['../ghostunnel', 'client', '--listen={0}:13004'.format(LOCALHOST),
+    ghostunnel = run_ghostunnel(['client', '--listen={0}:13004'.format(LOCALHOST),
       '--target=localhost:13005', '--keystore=client.p12', '--cacert=root.crt',
       '--override-server-name=foobar', '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
@@ -46,5 +46,5 @@ if __name__ == "__main__":
 
     print_ok("OK")
   finally:
-    if ghostunnel:
-      ghostunnel.kill()
+    terminate(ghostunnel)
+      

--- a/tests/test-client-rejects-invalid-san-or-ca.py
+++ b/tests/test-client-rejects-invalid-san-or-ca.py
@@ -4,7 +4,7 @@
 # not root2.
 
 from subprocess import Popen
-from test_common import RootCert, LOCALHOST, STATUS_PORT, SocketPair, print_ok, TcpClient, TlsServer
+from test_common import *
 import socket, ssl
 
 if __name__ == "__main__":
@@ -20,7 +20,7 @@ if __name__ == "__main__":
     other_root.create_signed_cert('other_server')
 
     # start ghostunnel
-    ghostunnel = Popen(['../ghostunnel', 'client', '--listen={0}:13004'.format(LOCALHOST),
+    ghostunnel = run_ghostunnel(['client', '--listen={0}:13004'.format(LOCALHOST),
       '--target=localhost:13005', '--keystore=client.p12', '--cacert=root.crt',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
@@ -46,5 +46,5 @@ if __name__ == "__main__":
 
     print_ok("OK")
   finally:
-    if ghostunnel:
-      ghostunnel.kill()
+    terminate(ghostunnel)
+      

--- a/tests/test-client-reloads-certificate.py
+++ b/tests/test-client-reloads-certificate.py
@@ -8,7 +8,7 @@
 # - tunnel picks up client cert change and uses it on the status port.
 
 from subprocess import Popen
-from test_common import RootCert, LOCALHOST, STATUS_PORT, SocketPair, TcpClient, TlsServer, TlsClient, print_ok
+from test_common import *
 import socket, ssl, time, os, signal
 
 if __name__ == "__main__":
@@ -25,7 +25,7 @@ if __name__ == "__main__":
     root2.create_signed_cert('client2')
 
     # start ghostunnel
-    ghostunnel = Popen(['../ghostunnel', 'client', '--listen={0}:13004'.format(LOCALHOST),
+    ghostunnel = run_ghostunnel(['client', '--listen={0}:13004'.format(LOCALHOST),
       '--target={0}:13005'.format(LOCALHOST), '--keystore=client1.p12',
       '--cacert=root1.crt', '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
@@ -47,12 +47,13 @@ if __name__ == "__main__":
     pair2 = SocketPair(TcpClient(13004), TlsServer('server1', 'root1', 13005))
     pair2.validate_can_send_from_client("toto", "pair2 works")
     pair2.validate_client_cert("new_client1", "pair2: ou=new_client1 -> ...")
+    pair2.cleanup()
 
     # ensure ghostunnel won't connect to server2
     try:
       pair3 = SocketPair(TcpClient(13004), TlsServer('server2', 'root1', 13005))
       pair3.validate_can_send_from_client("toto", "pair3 works")
-      raise Exception("pair2 worked")
+      raise Exception("pair3 worked")
     except ssl.SSLError as e:
       print_ok("ghostunnel did not connect to incorrect CA")
 
@@ -66,11 +67,13 @@ if __name__ == "__main__":
     pair4 = SocketPair(TcpClient(13004), TlsServer('server2', 'root1', 13005))
     pair4.validate_can_send_from_client("toto", "pair4 works")
     pair4.validate_client_cert("client2", "pair2: ou=client2 -> server2")
+    pair4.cleanup()
 
     # ensure that pair1 is still alive
     pair1.validate_can_send_from_client("toto", "pair1 still works")
+    pair1.cleanup()
     print_ok("OK")
 
   finally:
-    if ghostunnel:
-      ghostunnel.kill()
+    terminate(ghostunnel)
+      

--- a/tests/test-client-status-port.py
+++ b/tests/test-client-status-port.py
@@ -3,7 +3,7 @@
 # Creates a ghostunnel. Ensures that /_status endpoint works.
 
 from subprocess import Popen
-from test_common import RootCert, LOCALHOST, STATUS_PORT, SocketPair, print_ok, TcpClient, TlsClient, TlsServer
+from test_common import *
 import urllib.request, urllib.error, urllib.parse, socket, ssl, time, os, signal, json, sys
 
 if __name__ == "__main__":
@@ -16,7 +16,7 @@ if __name__ == "__main__":
 
     # start ghostunnel
     # hack: point target to STATUS_PORT so that /_status doesn't 503.
-    ghostunnel = Popen(['../ghostunnel', 'client', '--listen={0}:13004'.format(LOCALHOST),
+    ghostunnel = run_ghostunnel(['client', '--listen={0}:13004'.format(LOCALHOST),
       '--target={0}:{1}'.format(LOCALHOST, STATUS_PORT), '--keystore=client.p12',
       '--cacert=root.crt', '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
@@ -51,5 +51,5 @@ if __name__ == "__main__":
 
     print_ok("OK")
   finally:
-    if ghostunnel:
-      ghostunnel.kill()
+    terminate(ghostunnel)
+      

--- a/tests/test-client-unix-socket-backend.py
+++ b/tests/test-client-unix-socket-backend.py
@@ -3,7 +3,7 @@
 # Creates a ghostunnel. Ensures ghostunnel can listen on a unix socket.
 
 from subprocess import Popen
-from test_common import RootCert, LOCALHOST, STATUS_PORT, SocketPair, print_ok, TlsServer, UnixClient
+from test_common import *
 import socket, ssl, tempfile, os
 
 if __name__ == "__main__":
@@ -16,7 +16,7 @@ if __name__ == "__main__":
 
     # start ghostunnel
     socket = UnixClient()
-    ghostunnel = Popen(['../ghostunnel', 'client', '--listen=unix:{0}'.format(socket.get_socket_path()),
+    ghostunnel = run_ghostunnel(['client', '--listen=unix:{0}'.format(socket.get_socket_path()),
       '--target={0}:13005'.format(LOCALHOST), '--keystore=client.p12',
       '--cacert=root.crt', '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
@@ -29,5 +29,5 @@ if __name__ == "__main__":
 
     print_ok("OK")
   finally:
-    if ghostunnel:
-      ghostunnel.kill()
+    terminate(ghostunnel)
+      

--- a/tests/test-server-concurrent-connections.py
+++ b/tests/test-server-concurrent-connections.py
@@ -4,7 +4,7 @@
 
 from subprocess import Popen
 from multiprocessing import Process
-from test_common import RootCert, LOCALHOST, STATUS_PORT, SocketPair, print_ok, TlsClient, TcpServer
+from test_common import *
 import socket, ssl, time, random
 
 def send_data(i, p):
@@ -39,7 +39,7 @@ if __name__ == "__main__":
       allow_ou.append("--allow-ou=client{0}".format(i))
 
     # start ghostunnel
-    ghostunnel = Popen(['../ghostunnel', 'server', '--listen={0}:13001'.format(LOCALHOST),
+    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
       '--target={0}:13002'.format(LOCALHOST), '--keystore=server.p12',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
       '--cacert=root.crt'] + allow_ou)
@@ -56,5 +56,5 @@ if __name__ == "__main__":
 
     print_ok("OK")
   finally:
-    if ghostunnel:
-      ghostunnel.kill()
+    terminate(ghostunnel)
+      

--- a/tests/test-server-handles-client-closes-connection.py
+++ b/tests/test-server-handles-client-closes-connection.py
@@ -4,7 +4,7 @@
 # connection also disconnects.
 
 from subprocess import Popen
-from test_common import RootCert, LOCALHOST, STATUS_PORT, SocketPair, print_ok, TlsClient, TcpServer
+from test_common import *
 import socket, ssl
 
 if __name__ == "__main__":
@@ -16,7 +16,7 @@ if __name__ == "__main__":
     root.create_signed_cert('client')
 
     # start ghostunnel
-    ghostunnel = Popen(['../ghostunnel', 'server', '--listen={0}:13001'.format(LOCALHOST),
+    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
       '--target={0}:13002'.format(LOCALHOST), '--keystore=server.p12',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
       '--cacert=root.crt', '--allow-ou=client'])
@@ -29,5 +29,5 @@ if __name__ == "__main__":
 
     print_ok("OK")
   finally:
-    if ghostunnel:
-      ghostunnel.kill()
+    terminate(ghostunnel)
+      

--- a/tests/test-server-handles-no-server.py
+++ b/tests/test-server-handles-no-server.py
@@ -4,7 +4,7 @@
 # server.
 
 from subprocess import Popen
-from test_common import RootCert, LOCALHOST, STATUS_PORT, SocketPair, print_ok, TlsClient, TcpServer
+from test_common import *
 import socket, ssl
 
 if __name__ == "__main__":
@@ -16,7 +16,7 @@ if __name__ == "__main__":
     root.create_signed_cert('client')
 
     # start ghostunnel
-    ghostunnel = Popen(['../ghostunnel', 'server', '--listen={0}:13001'.format(LOCALHOST),
+    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
       '--target={0}:13002'.format(LOCALHOST), '--keystore=server.p12',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
       '--cacert=root.crt', '--allow-ou=client'])
@@ -30,7 +30,8 @@ if __name__ == "__main__":
 
     # client should connect
     pair = SocketPair(TlsClient('client', 'root', 13001), TcpServer(13002))
+    pair.cleanup()
     print_ok("OK")
   finally:
-    if ghostunnel:
-      ghostunnel.kill()
+    terminate(ghostunnel)
+      

--- a/tests/test-server-handles-server-closes-connection.py
+++ b/tests/test-server-handles-server-closes-connection.py
@@ -4,7 +4,7 @@
 # connection also disconnects.
 
 from subprocess import Popen
-from test_common import RootCert, LOCALHOST, STATUS_PORT, SocketPair, print_ok, TlsClient, TcpServer
+from test_common import *
 import socket, ssl
 
 if __name__ == "__main__":
@@ -16,7 +16,7 @@ if __name__ == "__main__":
     root.create_signed_cert('client')
 
     # start ghostunnel
-    ghostunnel = Popen(['../ghostunnel', 'server', '--listen={0}:13001'.format(LOCALHOST),
+    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
       '--target={0}:13000'.format(LOCALHOST), '--keystore=server.p12',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
       '--cacert=root.crt', '--allow-ou=client'])
@@ -29,5 +29,5 @@ if __name__ == "__main__":
 
     print_ok("OK")
   finally:
-    if ghostunnel:
-      ghostunnel.kill()
+    terminate(ghostunnel)
+      

--- a/tests/test-server-metrics-bridge.py
+++ b/tests/test-server-metrics-bridge.py
@@ -3,7 +3,7 @@
 # Creates a ghostunnel. Ensures that /_status endpoint works.
 
 from subprocess import Popen
-from test_common import RootCert, LOCALHOST, STATUS_PORT, print_ok
+from test_common import *
 import urllib.request, urllib.error, urllib.parse, socket, ssl, time, os, signal, json, http.server, threading
 
 received_metrics = None
@@ -27,7 +27,7 @@ if __name__ == "__main__":
     server.start()
 
     # start ghostunnel
-    ghostunnel = Popen(['../ghostunnel', 'server', '--listen={0}:13001'.format(LOCALHOST),
+    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
       '--target={0}:13002'.format(LOCALHOST), '--keystore=server.p12',
       '--cacert=root.crt', '--allow-ou=client',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
@@ -49,5 +49,5 @@ if __name__ == "__main__":
 
     print_ok("OK")
   finally:
-    if ghostunnel:
-      ghostunnel.kill()
+    terminate(ghostunnel)
+      

--- a/tests/test-server-metrics-graphite.py
+++ b/tests/test-server-metrics-graphite.py
@@ -3,7 +3,7 @@
 # Creates a ghostunnel. Ensures that /_status endpoint works.
 
 from subprocess import Popen
-from test_common import RootCert, LOCALHOST, STATUS_PORT, print_ok
+from test_common import *
 import urllib.request, urllib.error, urllib.parse, socket, ssl, time, os, signal, json, http.server, threading
 
 if __name__ == "__main__":
@@ -21,7 +21,7 @@ if __name__ == "__main__":
     m.listen(1)
 
     # start ghostunnel
-    ghostunnel = Popen(['../ghostunnel', 'server', '--listen={0}:13001'.format(LOCALHOST),
+    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
       '--target={0}:13100'.format(LOCALHOST), '--keystore=server.p12',
       '--cacert=root.crt', '--allow-ou=client',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
@@ -35,5 +35,5 @@ if __name__ == "__main__":
 
     print_ok("OK")
   finally:
-    if ghostunnel:
-      ghostunnel.kill()
+    terminate(ghostunnel)
+      

--- a/tests/test-server-rejects-invalid-ou-or-ca.py
+++ b/tests/test-server-rejects-invalid-ou-or-ca.py
@@ -4,7 +4,7 @@
 # ou=client2 or ca=other_root can't connect.
 
 from subprocess import Popen
-from test_common import RootCert, LOCALHOST, STATUS_PORT, SocketPair, print_ok, TlsClient, TcpServer
+from test_common import *
 import socket, ssl
 
 if __name__ == "__main__":
@@ -20,7 +20,7 @@ if __name__ == "__main__":
     other_root.create_signed_cert('other_client1')
 
     # start ghostunnel
-    ghostunnel = Popen(['../ghostunnel', 'server', '--listen={0}:13001'.format(LOCALHOST),
+    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
       '--target={0}:13002'.format(LOCALHOST), '--keystore=server.p12',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
       '--cacert=root.crt', '--allow-ou=client1'])
@@ -49,5 +49,5 @@ if __name__ == "__main__":
 
     print_ok("OK")
   finally:
-    if ghostunnel:
-      ghostunnel.kill()
+    terminate(ghostunnel)
+      

--- a/tests/test-server-reloads-root-certificate.py
+++ b/tests/test-server-reloads-root-certificate.py
@@ -4,7 +4,7 @@
 # change.
 
 from subprocess import Popen, call
-from test_common import RootCert, LOCALHOST, STATUS_PORT, SocketPair, print_ok, TlsClient, TcpServer
+from test_common import *
 import socket, ssl, time, signal, os
 
 if __name__ == "__main__":
@@ -21,7 +21,7 @@ if __name__ == "__main__":
     new_root.create_signed_cert('client3')
 
     # start ghostunnel
-    ghostunnel = Popen(['../ghostunnel', 'server', '--listen={0}:13001'.format(LOCALHOST),
+    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
       '--target={0}:13002'.format(LOCALHOST), '--keystore=server.p12',
       '--cacert=root.crt', '--allow-ou=client1', '--allow-ou=client2',
       '--allow-ou=client3', '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
@@ -45,6 +45,7 @@ if __name__ == "__main__":
     # ensure that client3 can connect
     pair3 = SocketPair(TlsClient('client3', 'root', 13001), TcpServer(13002))
     pair3.validate_can_send_from_client("toto", "pair3 works")
+    pair3.cleanup()
 
     # ensure that client2 cannot connect
     try:
@@ -56,8 +57,10 @@ if __name__ == "__main__":
     # ensure that pair1 and pair2 are still alive
     pair1.validate_can_send_from_client("toto", "pair1 still works")
     pair2.validate_can_send_from_client("toto", "pair2 still works")
+    pair1.cleanup()
+    pair2.cleanup()
 
     print_ok("OK")
   finally:
-    if ghostunnel:
-      ghostunnel.kill()
+    terminate(ghostunnel)
+      

--- a/tests/test-server-status-port.py
+++ b/tests/test-server-status-port.py
@@ -3,7 +3,7 @@
 # Creates a ghostunnel. Ensures that /_status endpoint works.
 
 from subprocess import Popen
-from test_common import RootCert, LOCALHOST, STATUS_PORT, SocketPair, print_ok, TcpClient, TlsClient, TcpServer
+from test_common import *
 import urllib.request, urllib.error, urllib.parse, socket, ssl, time, os, signal, json, sys
 
 if __name__ == "__main__":
@@ -17,7 +17,7 @@ if __name__ == "__main__":
 
     # start ghostunnel
     # hack: point target to STATUS_PORT so that /_status doesn't 503.
-    ghostunnel = Popen(['../ghostunnel', 'server', '--listen={0}:13001'.format(LOCALHOST),
+    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
       '--target={0}:{1}'.format(LOCALHOST, STATUS_PORT), '--keystore=server.p12',
       '--cacert=root.crt', '--allow-ou=client',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
@@ -53,5 +53,5 @@ if __name__ == "__main__":
 
     print_ok("OK")
   finally:
-    if ghostunnel:
-      ghostunnel.kill()
+    terminate(ghostunnel)
+      

--- a/tests/test-server-unix-socket-backend.py
+++ b/tests/test-server-unix-socket-backend.py
@@ -3,7 +3,7 @@
 # Creates a ghostunnel. Ensures ghostunnel can connect to a unix socket.
 
 from subprocess import Popen
-from test_common import RootCert, LOCALHOST, STATUS_PORT, SocketPair, print_ok, TlsClient, UnixServer
+from test_common import *
 import socket, ssl, tempfile, os
 
 if __name__ == "__main__":
@@ -16,7 +16,7 @@ if __name__ == "__main__":
 
     # start ghostunnel
     socket = UnixServer()
-    ghostunnel = Popen(['../ghostunnel', 'server', '--listen={0}:13001'.format(LOCALHOST),
+    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
       '--target=unix:{0}'.format(socket.get_socket_path()), '--keystore=server.p12',
       '--cacert=root.crt', '--allow-ou=client', '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
@@ -28,5 +28,5 @@ if __name__ == "__main__":
 
     print_ok("OK")
   finally:
-    if ghostunnel:
-      ghostunnel.kill()
+    terminate(ghostunnel)
+      


### PR DESCRIPTION
r: @alokmenghrajani @mcpherrinm 
Generate test coverage for integration tests. This pull request changes our integration test suite to run ghostunnel through an integration test hook in `main_test.go`, so that we can record coverage information for the external tests we run. Also adds a badge to the repo to show coverage.

Inspiration from: https://www.elastic.co/blog/code-coverage-for-your-golang-system-tests
Coverage information here: https://coveralls.io/github/square/ghostunnel