### PR TITLE
Simplify build scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ before_install:
   - go get github.com/axw/gocov/gocov
   - go get github.com/mattn/goveralls
   - go get golang.org/x/tools/cmd/cover
-  - make depends
 
 install:
   - make build 

--- a/README.md
+++ b/README.md
@@ -74,10 +74,6 @@ Then, build ghostunnel and run tests:
     make build
     make test
 
-If you want to update vendored dependencies:
-
-    make update-depends
-
 Ghostunnel is tested with Go 1.6, and our integration test suite requires
 Python 3.5.
 

--- a/main.go
+++ b/main.go
@@ -37,11 +37,11 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
-// These are initialized via -ldflags
-var buildRevision = "unknown"
-var buildCompiler = "unknown"
-
-var defaultMetricsPrefix = "ghostunnel"
+var (
+	// Initialized via -ldflags
+	buildRevision        = "unknown"
+	defaultMetricsPrefix = "ghostunnel"
+)
 
 var (
 	app = kingpin.New("ghostunnel", "A simple SSL/TLS proxy with mutual authentication for securing non-TLS services.")
@@ -163,7 +163,7 @@ func run(args []string) {
 	initLogger()
 	runtime.GOMAXPROCS(runtime.NumCPU())
 
-	app.Version(fmt.Sprintf("rev %s built with %s", buildRevision, buildCompiler))
+	app.Version(fmt.Sprintf("rev %s built with %s", buildRevision, runtime.Version()))
 	app.Validate(validateFlags)
 	command := kingpin.MustParse(app.Parse(args))
 

--- a/status.go
+++ b/status.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"runtime"
 	"sync"
 	"time"
 )
@@ -72,7 +73,7 @@ func (s *statusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp.Revision = buildRevision
-	resp.Compiler = buildCompiler
+	resp.Compiler = runtime.Version()
 
 	conn, err := s.dial()
 	resp.BackendOk = err == nil

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+from subprocess import run
+import sys, time, subprocess
+
+test = sys.argv[1]
+path = './%s.py' % test
+
+print("=== RUN   %s" % test)
+
+start = time.time()
+proc = run([path], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+end = time.time()
+
+if proc.returncode == 0:
+  print("=== PASS: %s (%.2fs)" % (test, end - start))
+else:
+  sys.stdout.buffer.write(proc.stdout)
+  sys.stdout.buffer.write(proc.stderr)
+  print("=== FAIL: %s (%.2fs)" % (test, end - start))
+
+sys.exit(proc.returncode)


### PR DESCRIPTION
r: @alokmenghrajani @mcpherrinm @sqshh 
Simplifies the make file, changes the way we run integration tests. In particular, only print stdout/stderr from integration tests if they fail. Otherwise just print "PASS" and move on. Also prints time taken per test.