### PR TITLE
Timeouts for backend connections, handshakes.

### DIFF
--- a/tests/test-server-tls-handshake-timeout.py
+++ b/tests/test-server-tls-handshake-timeout.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+# Simulates a hanging handshake, waits for timeout. 
+
+from subprocess import Popen
+from test_common import *
+import urllib.request, urllib.error, urllib.parse, socket, ssl, time, os, signal, json, sys, errno
+
+if __name__ == "__main__":
+  ghostunnel = None
+  try:
+    # create certs
+    root = RootCert('root')
+    root.create_signed_cert('server')
+    root.create_signed_cert('new_server')
+    root.create_signed_cert('client')
+
+    # start ghostunnel
+    ghostunnel = run_ghostunnel(['server', '--listen={0}:13000'.format(LOCALHOST),
+      '--target={0}:13001'.format(LOCALHOST), '--keystore=server.p12',
+      '--cacert=root.crt', '--allow-ou=client', '--timeout=1s',
+      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
+
+    # connect but don't perform handshake
+    client = TcpClient(13000)
+    client.connect(20)
+    client.get_socket().setblocking(False)
+
+    urlopen = lambda path: urllib.request.urlopen(path, cafile='root.crt')
+
+    # wait until handshake times out
+    timeout = False
+    for _ in range(0, 20):
+      metrics = json.loads(str(urlopen("https://{0}:{1}/_metrics".format(LOCALHOST, STATUS_PORT)).read(), 'utf-8'))
+      timeouts = [m['value'] for m in metrics if "accept.timeout" in m['metric']]
+      if timeouts[0] > 0:
+        print_ok("handshake timed out, as expected")
+        timeout = True
+        break
+      time.sleep(1)
+
+    if not timeout:
+      raise Exception("socket still appears to be open after timeout")
+
+    print_ok("OK")
+  finally:
+    terminate(ghostunnel)
+      

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -34,6 +34,18 @@ def terminate(ghostunnel):
     print_ok("timeout, killing ghostunnel")
     ghostunnel.kill()
 
+# Attempt to dump goroutines via status port/pprof
+def dump_goroutines():
+  ctx = ssl.create_default_context()
+  ctx.check_hostname = False
+  ctx.verify_mode = ssl.CERT_NONE
+  try:
+    sys.stderr.buffer.write(urllib.request.urlopen(
+        "https://{0}:{1}/debug/pprof/goroutine?debug=1".format(LOCALHOST, STATUS_PORT),
+        context=ctx).read())
+  except Exception as e:
+    print('unable to dump goroutines:', e)
+
 # Helper class to create root + signed certs
 class RootCert:
   def __init__(self, name):


### PR DESCRIPTION
r: @alokmenghrajani @mcpherrinm @stouset 

Avoid blocking whenever possible:
* we time out when dialing backend connections (both in client and server mode)
* we time out if a TLS handshake is taking too long (forcibly kill via deadline)
* perform handshake in background routine to not block accept loop
