### PR TITLE
Initial chain-exec support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ go:
   - 1.6
 
 before_install:
+  - sudo apt-get install -y netcat
   - go get github.com/Masterminds/glide
   - go get github.com/wadey/gocovmerge
   - go get github.com/mattn/goveralls

--- a/net.go
+++ b/net.go
@@ -71,11 +71,7 @@ func serverAccept(listener net.Listener, wg *sync.WaitGroup, stopper chan bool, 
 			defer conn.Close()
 			defer openCounter.Dec(1)
 
-			logger.Printf("incoming connection: %s", conn.RemoteAddr())
-			tlsConn, ok := conn.(*tls.Conn)
-			if !ok {
-				panic("got non-TLS socket from a TLS listener")
-			}
+			tlsConn := conn.(*tls.Conn)
 
 			// Force handshake. Handshake usually happens on first read/write, but
 			// we want to authenticate before reading/writing so we need to force
@@ -146,8 +142,6 @@ func clientAccept(listener net.Listener, stopper chan bool, dial func() (net.Con
 			logger.Printf("error accepting connection: %s", err)
 			continue
 		}
-
-		logger.Printf("incoming connection: %s", conn.RemoteAddr())
 
 		handlers.Add(1)
 		go timer.Time(func() {

--- a/status.go
+++ b/status.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/exec"
 	"runtime"
 	"sync"
 	"time"
@@ -31,6 +32,8 @@ type statusHandler struct {
 	mu *sync.Mutex
 	// Backend dialer to check if target is up and running
 	dial func() (net.Conn, error)
+	// Child process (if chain-execed, may be nil)
+	child *exec.Cmd
 	// Current status
 	listening bool
 	reloading bool
@@ -42,6 +45,7 @@ type statusResponse struct {
 	BackendOk     bool      `json:"backend_ok"`
 	BackendStatus string    `json:"backend_status"`
 	BackendError  string    `json:"backend_error,omitempty"`
+	ChildPid      *int      `json:"child_pid,omitempty"`
 	Time          time.Time `json:"time"`
 	Hostname      string    `json:"hostname,omitempty"`
 	Message       string    `json:"message"`
@@ -49,8 +53,8 @@ type statusResponse struct {
 	Compiler      string    `json:"compiler"`
 }
 
-func newStatusHandler(dial func() (net.Conn, error)) *statusHandler {
-	status := &statusHandler{&sync.Mutex{}, dial, false, false}
+func newStatusHandler(dial func() (net.Conn, error), child *exec.Cmd) *statusHandler {
+	status := &statusHandler{&sync.Mutex{}, dial, child, false, false}
 	return status
 }
 
@@ -84,6 +88,10 @@ func (s *statusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	} else {
 		resp.BackendError = err.Error()
 		resp.BackendStatus = "critical"
+	}
+
+	if s.child != nil && s.child.Process != nil {
+		resp.ChildPid = &s.child.Process.Pid
 	}
 
 	s.mu.Lock()

--- a/status_test.go
+++ b/status_test.go
@@ -62,7 +62,7 @@ func dummyDialError() (net.Conn, error) {
 }
 
 func TestStatusHandlerNew(t *testing.T) {
-	handler := newStatusHandler(dummyDial)
+	handler := newStatusHandler(dummyDial, nil)
 	response := httptest.NewRecorder()
 	handler.ServeHTTP(response, nil)
 
@@ -72,7 +72,7 @@ func TestStatusHandlerNew(t *testing.T) {
 }
 
 func TestStatusHandlerListening(t *testing.T) {
-	handler := newStatusHandler(dummyDial)
+	handler := newStatusHandler(dummyDial, nil)
 	response := httptest.NewRecorder()
 	handler.Listening()
 	handler.ServeHTTP(response, nil)
@@ -83,7 +83,7 @@ func TestStatusHandlerListening(t *testing.T) {
 }
 
 func TestStatusHandlerListeningBackendDown(t *testing.T) {
-	handler := newStatusHandler(dummyDialError)
+	handler := newStatusHandler(dummyDialError, nil)
 	response := httptest.NewRecorder()
 	handler.Listening()
 	handler.ServeHTTP(response, nil)
@@ -94,7 +94,7 @@ func TestStatusHandlerListeningBackendDown(t *testing.T) {
 }
 
 func TestStatusHandlerReloading(t *testing.T) {
-	handler := newStatusHandler(dummyDial)
+	handler := newStatusHandler(dummyDial, nil)
 	response := httptest.NewRecorder()
 	handler.Listening()
 	handler.Reloading()

--- a/tests/test-client-chain-exec-error.py
+++ b/tests/test-client-chain-exec-error.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+# Creates a ghostunnel with a subprocess (netcat), connects, and waits for termination.
+
+from subprocess import Popen
+from test_common import *
+import socket, ssl, time, os, signal
+
+if __name__ == "__main__":
+  ghostunnel = None
+  try:
+    # create certs
+    root = RootCert('root')
+    root.create_signed_cert('client')
+
+    # start ghostunnel server with false as child
+    ghostunnel = run_ghostunnel(['client', '--listen={0}:13001'.format(LOCALHOST),
+      '--target={0}:13002'.format(LOCALHOST), '--keystore=client.p12',
+      '--cacert=root.crt', '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
+      '--', 'false'])
+
+    # should terminate by itself (since child terminates)
+    for i in range(0, 10):
+      try:
+        ghostunnel.wait(timeout=1)
+      except:
+        pass
+      if ghostunnel.returncode != None:
+        if ghostunnel.returncode == 0:
+          raise Exception("got error code 0, even though child exited with non-zero")
+        else:
+          print_ok("non-zero error code if child has non-zero error code")
+          break
+      time.sleep(1)
+
+    print_ok("OK")
+  finally:
+    terminate(ghostunnel)

--- a/tests/test-client-chain-exec-success.py
+++ b/tests/test-client-chain-exec-success.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+# Creates a ghostunnel with a subprocess (netcat), connects, and waits for termination.
+
+from subprocess import Popen
+from test_common import *
+import socket, ssl, time, os, signal
+
+if __name__ == "__main__":
+  ghostunnel = None
+  try:
+    # create certs
+    root = RootCert('root')
+    root.create_signed_cert('client')
+
+    # start ghostunnel server with false as child
+    ghostunnel = run_ghostunnel(['client', '--listen={0}:13001'.format(LOCALHOST),
+      '--target={0}:13002'.format(LOCALHOST), '--keystore=client.p12',
+      '--cacert=root.crt', '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
+      '--', 'true'])
+
+    # should terminate by itself (since child terminates)
+    for i in range(0, 10):
+      try:
+        ghostunnel.wait(timeout=1)
+      except:
+        pass
+      if ghostunnel.returncode != None:
+        if ghostunnel.returncode == 0:
+          print_ok("exited normally")
+          sys.exit(0)
+        else:
+          raise Exception("got non-zero error code, even though child exited normally?")
+      time.sleep(1)
+
+    print_ok("OK")
+  finally:
+    terminate(ghostunnel)

--- a/tests/test-server-chain-exec-enoent.py
+++ b/tests/test-server-chain-exec-enoent.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+# Creates a ghostunnel with a subprocess (netcat), connects, and waits for termination.
+
+from subprocess import Popen
+from test_common import *
+import socket, ssl, time, os, signal
+
+if __name__ == "__main__":
+  ghostunnel = None
+  try:
+    # create certs
+    root = RootCert('root')
+    root.create_signed_cert('server')
+
+    # start ghostunnel server with false as child
+    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
+      '--target={0}:13002'.format(LOCALHOST), '--keystore=server.p12',
+      '--cacert=root.crt', '--allow-ou=client',
+      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
+      '--', 'does-not-exist'])
+
+    # should terminate by itself (since child terminates)
+    for i in range(0, 10):
+      try:
+        ghostunnel.wait(timeout=1)
+      except:
+        pass
+      if ghostunnel.returncode != None:
+        if ghostunnel.returncode == 0:
+          raise Exception("got error code 0, even though child exited with non-zero")
+        else:
+          print_ok("non-zero error code if child has non-zero error code")
+          break
+      time.sleep(1)
+
+    print_ok("OK")
+  finally:
+    terminate(ghostunnel)

--- a/tests/test-server-chain-exec-error.py
+++ b/tests/test-server-chain-exec-error.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+# Creates a ghostunnel with a subprocess (netcat), connects, and waits for termination.
+
+from subprocess import Popen
+from test_common import *
+import socket, ssl, time, os, signal
+
+if __name__ == "__main__":
+  ghostunnel = None
+  try:
+    # create certs
+    root = RootCert('root')
+    root.create_signed_cert('server')
+
+    # start ghostunnel server with false as child
+    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
+      '--target={0}:13002'.format(LOCALHOST), '--keystore=server.p12',
+      '--cacert=root.crt', '--allow-ou=client',
+      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
+      '--', 'false'])
+
+    # should terminate by itself (since child terminates)
+    for i in range(0, 10):
+      try:
+        ghostunnel.wait(timeout=1)
+      except:
+        pass
+      if ghostunnel.returncode != None:
+        if ghostunnel.returncode == 0:
+          raise Exception("got error code 0, even though child exited with non-zero")
+        else:
+          print_ok("non-zero error code if child has non-zero error code")
+          break
+      time.sleep(1)
+
+    print_ok("OK")
+  finally:
+    terminate(ghostunnel)

--- a/tests/test-server-chain-exec-success.py
+++ b/tests/test-server-chain-exec-success.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+# Creates a ghostunnel with a subprocess (netcat), connects, and waits for termination.
+
+from subprocess import Popen
+from test_common import *
+import socket, ssl, time, os, signal
+
+if __name__ == "__main__":
+  ghostunnel = None
+  try:
+    # create certs
+    root = RootCert('root')
+    root.create_signed_cert('server')
+    root.create_signed_cert('client')
+
+    # start ghostunnel server with nc as child
+    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
+      '--target={0}:13002'.format(LOCALHOST), '--keystore=server.p12',
+      '--cacert=root.crt', '--allow-ou=client',
+      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
+      '--', 'nc', '-l', LOCALHOST, '13002'])
+
+    # should terminate by itself (since child terminates)
+    for i in range(0, 20):
+      try:
+        # connect once (nc terminates after one connection)
+        TlsClient('client', 'root', 13001).connect(20)
+        ghostunnel.wait(timeout=1)
+      except:
+        pass
+      if ghostunnel.returncode != None:
+        if ghostunnel.returncode == 0:
+          print_ok("exited normally")
+          sys.exit(0)
+        else:
+          raise Exception("got non-zero error code, even though child exited normally?")
+      time.sleep(1)
+
+    raise Exception("did not terminate, though it should have")
+  finally:
+    terminate(ghostunnel)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -20,19 +20,22 @@ def run_ghostunnel(args):
 # Gracefully terminate ghostunnel (with timeout)
 def terminate(ghostunnel):
   print_ok("terminating ghostunnel instance")
-  if ghostunnel:
-    ghostunnel.terminate()
-    for i in range(0, 10):
-      try:
-        ghostunnel.wait(timeout=1)
-      except:
-        pass
-      if ghostunnel.returncode != None:
-        print_ok("ghostunnel stopped with exit code {0}".format(ghostunnel.returncode))
-        return
-      time.sleep(1)
-    print_ok("timeout, killing ghostunnel")
-    ghostunnel.kill()
+  try:
+    if ghostunnel:
+      ghostunnel.terminate()
+      for i in range(0, 10):
+        try:
+          ghostunnel.wait(timeout=1)
+        except:
+          pass
+        if ghostunnel.returncode is not None:
+          print_ok("ghostunnel stopped with exit code {0}".format(ghostunnel.returncode))
+          return
+        time.sleep(1)
+      print_ok("timeout, killing ghostunnel")
+      ghostunnel.kill()
+  except:
+    pass
 
 # Attempt to dump goroutines via status port/pprof
 def dump_goroutines():


### PR DESCRIPTION
r: @alokmenghrajani @mcpherrinm @sqshh 

Support for chaining execution of a subprocess. Makes it easier to coordinate processes.

For example, can now wrap a child command like:

    ghostunnel server [FLAGS] -- redis-server

Launches the given command on startup before listening. If the child process exits, the tunnel also exits along with it. Prevents stale tunnels from hanging around after their backend has terminated, and makes sure a process manager above us notices that we're shut down and can restart appropriately. 