### PR TITLE
Fix behavior of multiple SIGTERM on client

### DIFF
--- a/main.go
+++ b/main.go
@@ -71,6 +71,7 @@ var (
 	keystorePass    = app.Flag("storepass", "Password for certificate and keystore (optional).").PlaceHolder("PASS").String()
 	caBundlePath    = app.Flag("cacert", "Path to certificate authority bundle file (PEM/X509).").Required().String()
 	timedReload     = app.Flag("timed-reload", "Reload keystores every N seconds, refresh listener/client on changes.").PlaceHolder("N").Int()
+	shutdownTimeout = app.Flag("shutdown-timeout", "Graceful shutdown timeout. Terminates after timeout even if connections still open.").Default("5m").Duration()
 	timeoutDuration = app.Flag("timeout", "Timeout for establishing connections, handshakes.").Default("10s").Duration()
 	graphiteAddr    = app.Flag("graphite", "Collect metrics and report them to the given graphite instance (raw TCP).").PlaceHolder("ADDR").TCP()
 	metricsURL      = app.Flag("metrics-url", "Collect metrics and POST them periodically to the given URL (via HTTP/JSON).").PlaceHolder("URL").String()

--- a/signals.go
+++ b/signals.go
@@ -46,7 +46,7 @@ func serverSignalHandler(listener net.Listener, statusListener net.Listener, sto
 			switch sig {
 			case syscall.SIGTERM:
 				logger.Printf("received SIGTERM, stopping listener")
-				time.AfterFunc(5*time.Minute, func() {
+				time.AfterFunc(*shutdownTimeout, func() {
 					logger.Printf("graceful shutdown timeout: exiting")
 					exitFunc(1)
 				})
@@ -95,7 +95,7 @@ func clientSignalHandler(listener net.Listener, reloadClient chan bool, stopper 
 			switch sig {
 			case syscall.SIGTERM:
 				logger.Printf("received SIGTERM, stopping listener")
-				time.AfterFunc(5*time.Minute, func() {
+				time.AfterFunc(*shutdownTimeout, func() {
 					logger.Printf("graceful shutdown timeout: exiting")
 					exitFunc(1)
 				})

--- a/signals.go
+++ b/signals.go
@@ -90,6 +90,7 @@ func clientSignalHandler(listener net.Listener, reloadClient chan bool, stopper 
 			switch sig {
 			case syscall.SIGTERM:
 				logger.Printf("received SIGTERM, stopping listener")
+				signal.Stop(signals)
 				stopper <- true
 				listener.Close()
 				return

--- a/signals.go
+++ b/signals.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 )
 
 // signalHandler for server mode. Listens for incoming SIGTERM or SIGUSR1
@@ -45,6 +46,10 @@ func serverSignalHandler(listener net.Listener, statusListener net.Listener, sto
 			switch sig {
 			case syscall.SIGTERM:
 				logger.Printf("received SIGTERM, stopping listener")
+				time.AfterFunc(5*time.Minute, func() {
+					logger.Printf("graceful shutdown timeout: exiting")
+					exitFunc(1)
+				})
 				return
 
 			case syscall.SIGUSR1:
@@ -90,6 +95,10 @@ func clientSignalHandler(listener net.Listener, reloadClient chan bool, stopper 
 			switch sig {
 			case syscall.SIGTERM:
 				logger.Printf("received SIGTERM, stopping listener")
+				time.AfterFunc(5*time.Minute, func() {
+					logger.Printf("graceful shutdown timeout: exiting")
+					exitFunc(1)
+				})
 				signal.Stop(signals)
 				stopper <- true
 				listener.Close()

--- a/tests/test-client-shutdown-sigterm.py
+++ b/tests/test-client-shutdown-sigterm.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+from subprocess import Popen
+from test_common import *
+import socket, ssl, time, os, signal
+
+if __name__ == "__main__":
+  ghostunnel = None
+  try:
+    # create certs
+    root = RootCert('root')
+    root.create_signed_cert('server')
+    root.create_signed_cert('client')
+
+    # start ghostunnel
+    ghostunnel = run_ghostunnel(['client', '--listen={0}:13001'.format(LOCALHOST),
+      '--target={0}:13002'.format(LOCALHOST), '--keystore=server.p12',
+      '--cacert=root.crt', '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
+
+    # create connections with client
+    pair1 = SocketPair(TcpClient(13001), TlsServer('server', 'root', 13002))
+    pair1.validate_can_send_from_client("toto", "pair1 works")
+
+    # shut down ghostunnel with connection open, make sure it doesn't hang
+    print_ok('attempting to terminate ghostunnel via SIGTERM signals')
+    for n in range(0, 90):
+      try:
+        try:
+          ghostunnel.terminate()
+          ghostunnel.wait(timeout=1)
+        except:
+          pass
+        os.kill(ghostunnel.pid, 0)
+        print_ok("ghostunnel is still alive")
+      except:
+        stopped = True
+        break
+      time.sleep(1)
+
+    if not stopped:
+      raise Exception('ghostunnel did not terminate within 90 seconds')
+
+    print_ok("OK (terminated)")
+  finally:
+    terminate(ghostunnel)
+      

--- a/tests/test-server-shutdown-sigterm.py
+++ b/tests/test-server-shutdown-sigterm.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+from subprocess import Popen
+from test_common import *
+import socket, ssl, time, os, signal
+
+if __name__ == "__main__":
+  ghostunnel = None
+  try:
+    # create certs
+    root = RootCert('root')
+    root.create_signed_cert('server')
+    root.create_signed_cert('client')
+
+    # start ghostunnel
+    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
+      '--target={0}:13002'.format(LOCALHOST), '--keystore=server.p12',
+      '--cacert=root.crt', '--allow-ou=client',
+      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
+
+    # create connections with client
+    pair1 = SocketPair(TlsClient('client', 'root', 13001), TcpServer(13002))
+    pair1.validate_can_send_from_client("toto", "pair1 works")
+
+    # shut down ghostunnel with connection open, make sure it doesn't hang
+    print_ok('attempting to terminate ghostunnel via SIGTERM signals')
+    for n in range(0, 90):
+      try:
+        try:
+          ghostunnel.terminate()
+          ghostunnel.wait(timeout=1)
+        except:
+          pass
+        os.kill(ghostunnel.pid, 0)
+        print_ok("ghostunnel is still alive")
+      except:
+        stopped = True
+        break
+      time.sleep(1)
+
+    if not stopped:
+      raise Exception('ghostunnel did not terminate within 90 seconds')
+
+    print_ok("OK (terminated)")
+  finally:
+    terminate(ghostunnel)
+      


### PR DESCRIPTION
@alokmenghrajani @mcpherrinm @sqshh
Fix behavior of multiple SIGTERM on client: if we receive multiple SIGTERM signals, the client should always shut down. To do so, we unregister the signal handler for SIGTERM before exiting the client signal handler function. Also, this adds a hard timeout of 5 minutes for graceful shutdown after which we terminate even if there are still open connections.