### PR TITLE
Allow status port to be a UNIX socket

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,5 +21,9 @@ pre-integration:
 integration: pre-integration $(INTEGRATION_TESTS)
 	@echo "PASS"
 
+coverage: test
+	gocovmerge *.out */*.out > merged.coverprofile
+	go tool cover -html merged.coverprofile
+
 test-%:
 	@cd tests && ./test_runner.py $@

--- a/main_test.go
+++ b/main_test.go
@@ -47,6 +47,9 @@ func TestIntegrationMain(t *testing.T) {
 
 	finished := make(chan bool, 1)
 	once := &sync.Once{}
+
+	// override exit function for test, to make sure calls to exitFunc() don't
+	// actually terminate the process and kill the test w/o capturing results.
 	exitFunc = func(exit int) {
 		once.Do(func() {
 			if exit != 0 {
@@ -54,6 +57,7 @@ func TestIntegrationMain(t *testing.T) {
 			}
 		})
 		finished <- true
+		select {} // block
 	}
 
 	var wrappedArgs []string
@@ -91,7 +95,7 @@ func TestPanicOnError(t *testing.T) {
 
 func TestFlagValidation(t *testing.T) {
 	*enableProf = true
-	*statusAddr = nil
+	*statusAddress = ""
 	err := validateFlags(nil)
 	assert.NotNil(t, err, "--enable-pprof implies --status")
 

--- a/signals.go
+++ b/signals.go
@@ -30,15 +30,16 @@ import (
 // process. If we get SIGUSR1, reload certificates.
 func signalHandler(proxy *proxy, closeables []io.Closer, context *Context) {
 	signals := make(chan os.Signal)
-	signal.Notify(signals, syscall.SIGUSR1, syscall.SIGTERM)
+	signal.Notify(signals, syscall.SIGUSR1, syscall.SIGTERM, syscall.SIGINT)
 	defer signal.Stop(signals)
+	defer cleanup()
 
 	for {
 		// Wait for a signal
 		select {
 		case sig := <-signals:
 			switch sig {
-			case syscall.SIGTERM:
+			case syscall.SIGINT, syscall.SIGTERM:
 				logger.Printf("received SIGTERM, shutting down")
 				time.AfterFunc(*shutdownTimeout, func() {
 					logger.Printf("graceful shutdown timeout: exiting")

--- a/tests/test-server-status-port-unix.py
+++ b/tests/test-server-status-port-unix.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+# Creates a ghostunnel. Ensures that /_status endpoint using UNIX sockets works.
+
+from subprocess import Popen
+from test_common import *
+from tempfile import mkdtemp
+import urllib.request, urllib.error, urllib.parse, socket, ssl, time, os, signal, json, sys, http.client
+
+class UnixHTTPConnection(http.client.HTTPConnection):
+    def __init__(self, path):
+        super().__init__(self, 'localhost')
+        self.host = 'localhost'
+        self.path = path
+
+    def connect(self):
+        self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.sock.connect(self.path)
+
+if __name__ == "__main__":
+  ghostunnel = None
+  try:
+    # create certs
+    root = RootCert('root')
+    root.create_signed_cert('server')
+
+    # start ghostunnel
+    tempdir = mkdtemp()
+    path = os.path.join(tempdir, 'ghostunnel-status-socket')
+
+    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
+      '--target=unix:{0}'.format(path), '--keystore=server.p12',
+      '--cacert=root.crt', '--allow-ou=client',
+      '--status=unix:{0}'.format(path)])
+
+    # wait for startup
+    for i in range(0, 10):
+      if os.path.exists(path):
+        break
+      time.sleep(1)
+
+    # read status information
+    conn = UnixHTTPConnection(path)
+    conn.connect()
+
+    conn.request('GET', '/_status')
+    status = json.loads(str(conn.getresponse().read(), encoding="UTF-8"))
+
+    if not status['ok']:
+        raise Exception("ghostunnel reported non-ok status")
+
+    print_ok("OK")
+  finally:
+    terminate(ghostunnel)
+    os.rmdir(tempdir)
+      

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -11,6 +11,7 @@ TIMEOUT = 5
 def run_ghostunnel(args):
   os.environ["GHOSTUNNEL_INTEGRATION_TEST"] = "true"
   os.environ["GHOSTUNNEL_INTEGRATION_ARGS"] = json.dumps(args)
+  print_ok("running with args:\n {0}".format(' \ \n '.join(args)))
   test = os.path.basename(sys.argv[0]).replace('.py', '.out')
   return Popen([
       '../ghostunnel.test',
@@ -259,6 +260,7 @@ class UnixClient(MySocket):
     super().cleanup()
     self.socket = None
     os.remove(self.socket_path)
+    os.rmdir(os.path.dirname(self.socket_path))
 
 class UnixServer(MySocket):
   def __init__(self):


### PR DESCRIPTION
r: @alokmenghrajani @mcpherrinm @sqshh 

Changes to allow status port to be a UNIX socket via `--status=unix:PATH` (instead of just `HOST:PORT`).

This is useful in cases where we don't want to listen on _yet another_ port on a host.

To connect, just use curl:
```
$ curl -s --unix-socket /tmp/ghostunnel-status.sock http:/_status | jq .
{
  "ok": true,
  "status": "ok",
  "backend_ok": true,
  "backend_status": "ok",
  "child_pid": 40486,
  "time": "2016-04-30T19:39:01.5509053-07:00",
  "hostname": "carbon",
  "message": "listening",
  "revision": "v1.0.2-1-g930874df",
  "compiler": "go1.6"
}
```