### PR TITLE
Terminate child on exit timeout

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -53,7 +53,7 @@ func TestIntegrationMain(t *testing.T) {
 	exitFunc = func(exit int) {
 		once.Do(func() {
 			if exit != 0 {
-				t.Errorf("exit code from chid: %d", exit)
+				t.Errorf("exit code from ghostunnel: %d", exit)
 			}
 		})
 		finished <- true
@@ -65,7 +65,10 @@ func TestIntegrationMain(t *testing.T) {
 	panicOnError(err)
 
 	go func() {
-		run(wrappedArgs)
+		err := run(wrappedArgs)
+		if err != nil {
+			t.Errorf("got error from run: %s", err)
+		}
 		finished <- true
 	}()
 

--- a/tests/child-process-sigterm-trap.py
+++ b/tests/child-process-sigterm-trap.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+from common import *
+import sys, signal
+
+# Be naughty and ignore SIGTERM to simulate hanging child
+signal.signal(signal.SIGTERM, signal.SIG_IGN)
+
+# Start a server that listens for incoming connections
+try:
+    print_ok("child starting up on port %s" % sys.argv[1])
+    s = TcpServer(int(sys.argv[1]))
+    s.listen()
+    while True:
+        try:
+            s.socket, _ = s.listener.accept()
+            s.socket.settimeout(TIMEOUT)
+        except:
+            pass
+finally:
+    s.cleanup()
+
+print_ok("child exiting")

--- a/tests/test-server-chain-exec-shutdown-timeout.py
+++ b/tests/test-server-chain-exec-shutdown-timeout.py
@@ -10,12 +10,14 @@ if __name__ == "__main__":
     # create certs
     root = RootCert('root')
     root.create_signed_cert('server')
+    root.create_signed_cert('client')
 
     # start ghostunnel server with false as child
     ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
       '--target={0}:13002'.format(LOCALHOST), '--keystore=server.p12',
-      '--cacert=root.crt', '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
-      '--allow-all', '--', 'nc', '-kl', LOCALHOST, '13002'])
+      '--shutdown-timeout=1s', '--cacert=root.crt',
+      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
+      '--allow-all', '--', 'python3', 'child-process-sigterm-trap.py', '13002'])
 
     urlopen = lambda path: urllib.request.urlopen(path, cafile='root.crt')
 
@@ -28,7 +30,7 @@ if __name__ == "__main__":
     # send sigterm to ghostunnel, wait for child to terminate
     stopped = False
     ghostunnel.terminate()
-    for n in range(0, 10):
+    for n in range(0, 30):
       try:
         os.kill(status['child_pid'], 0)
         print_ok("child is still alive")
@@ -39,6 +41,23 @@ if __name__ == "__main__":
 
     if not stopped:
       raise Exception('child never terminated')
+
+    # wait for ghostunnel to terminate
+    for n in range(0, 90):
+      try:
+        try:
+          ghostunnel.wait(timeout=1)
+        except:
+          pass
+        os.kill(ghostunnel.pid, 0)
+        print_ok("ghostunnel is still alive")
+      except:
+        stopped = True
+        break
+      time.sleep(1)
+
+    if not stopped:
+      raise Exception('ghostunnel did not terminate within 90 seconds')
 
     print_ok("child terminated")
 


### PR DESCRIPTION
Previously, when ghostunnel would hit the graceful shutdown timeout, it would simply exit without signaling to the child process. This changes the logic to make sure we always terminate the child on exit. In addition, we also add a test to make sure that a misbehaving child which is ignoring SIGTERM is properly killed after timeout.