### PR TITLE
Fix double wording in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ some pre-generated ones in the `test-keys` directory (alongside instructions
 on how to generate new ones with OpenSSL).
 
 Note that by default ghostunnel logs to stderr and runs in the foreground. You
-can set set `--syslog` to log to syslog. For daemonization, we recommend using
+can set `--syslog` to log to syslog. For daemonization, we recommend using
 a utility such as [daemonize](http://software.clapper.org/daemonize/). For an
 example on how to use ghostunnel in a Docker container, see the `docker`
 subdirectory.


### PR DESCRIPTION
Fix double wording in readme