### PR TITLE
Use P-256 as only allowable curve

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,13 @@ server mode runs in front of a backend server and accepts TLS-secured
 connections, which are then proxied to the (insecure) backend. A backend can be
 a TCP domain/port or a UNIX domain socket. Ghostunnel in client mode accepts
 (insecure) connections through a TCP or UNIX domain socket and proxies them to
-a TLS-secured service.
+a TLS-secured service. In other words, ghostunnel is a replacement for stunnel.
 
-In other words, ghostunnel is a replacement for stunnel.
+**Supported platforms**: Ghostunnel is developed primarily for Linux on x86-64
+platforms, although it should run on any UNIX system that exposes SO_REUSEPORT,
+including Darwin, FreeBSD, OpenBSD and NetBSD. We recommed running on x86-64
+only, as Go (as of Go 1.7) doesn't have constant-time curve implementations for
+any other architectures.
 
 See `ghostunnel --help`, `ghostunnel server --help` and `ghostunnel client --help`.
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ a TLS-secured service. In other words, ghostunnel is a replacement for stunnel.
 
 **Supported platforms**: Ghostunnel is developed primarily for Linux on x86-64
 platforms, although it should run on any UNIX system that exposes SO_REUSEPORT,
-including Darwin, FreeBSD, OpenBSD and NetBSD. We recommed running on x86-64
-only, as Go (as of Go 1.7) doesn't have constant-time curve implementations for
-any other architectures.
+including Darwin (macOS), FreeBSD, OpenBSD and NetBSD. We recommed running on
+x86-64 only, as Go (as of Go 1.7) doesn't have constant-time elliptic curve
+implementations for any other architectures.
 
 See `ghostunnel --help`, `ghostunnel server --help` and `ghostunnel client --help`.
 

--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ import (
 )
 
 var (
-	version              = "v1.0.4"
+	version              = "v1.0.6"
 	defaultMetricsPrefix = "ghostunnel"
 )
 

--- a/tls.go
+++ b/tls.go
@@ -126,5 +126,9 @@ func buildConfig(caBundlePath string) (*tls.Config, error) {
 			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
 		},
+		CurvePreferences: []tls.CurveID{
+			// P-256 has an ASM implementation, others do not (as of 2016-12-19).
+			tls.CurveP256,
+		},
 	}, nil
 }


### PR DESCRIPTION
Changes:
* Use P-256 as the only allowable curve, as it is the only one that has an ASM implementation. 
* Mention that we only support x86-64 (other platforms don't have any constant-time curves).
* While we're at it, bump version for next release (1.0.6, we accidentally skipped 1.0.5). 