### PR TITLE
Add HTTP CONNECT proxy support

### DIFF
--- a/tests/test-client-via-http-connect-proxy.py
+++ b/tests/test-client-via-http-connect-proxy.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+from subprocess import Popen
+from common import *
+import socket, ssl, time, os, signal, json, http.server, threading, select
+
+class FakeConnectProxyHandler(http.server.BaseHTTPRequestHandler):
+  def do_CONNECT(self):
+    try:
+      host, port = self.path.split(':')
+      if host != '127.0.0.1':
+        raise Exception('proxy target must be localhost, but was: ' + self.path)
+      print_ok("got proxy request, with proxy target: " + self.path)
+      socket = TcpClient(int(port))
+      socket.connect(attempts=5)
+      self.wfile.write(bytearray("HTTP/1.1 200 Connection established\r\n", "utf-8"))
+      self.wfile.write(bytearray("Proxy-agent: FakeConnectProxyHandler\r\n\r\n", "utf-8"))
+      remote = socket.get_socket()
+      rlist = [self.connection, remote]
+      for _ in range(0, 1000):
+        reads, _, errs = select.select(rlist, [], rlist, 10)
+        if errs:
+          print_ok("got error in select(): " + str(errs))
+          break
+        for s in reads:
+          data = s.recv(8192)
+          if data:
+            print_ok("proxy is sending/receiving " + str(len(data)) + " bytes")
+            (self.connection if s == remote else remote).send(data)
+    finally:
+      print_ok("connect proxy is done")
+      try:
+        socket.get_socket().shutdown()
+        socket.cleanup()
+        self.connection.close()
+      except:
+        pass
+
+if __name__ == "__main__":
+  ghostunnel = None
+  try:
+    # create certs
+    root = RootCert('root')
+    root.create_signed_cert('server')
+    root.create_signed_cert('client')
+
+    httpd = http.server.HTTPServer(('localhost',13080), FakeConnectProxyHandler)
+    server = threading.Thread(target=httpd.handle_request)
+    server.start()
+
+    # start ghostunnel
+    ghostunnel = run_ghostunnel(['client', '--listen={0}:13001'.format(LOCALHOST),
+      '--target=localhost:13002', '--keystore=client.p12', '--cacert=root.crt',
+      '--connect-proxy=http://localhost:13080', '--timeout=30s',
+      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
+
+    # connect to server, confirm that the tunnel is up
+    pair = SocketPair(TcpClient(13001), TlsServer('server', 'root', 13002))
+    pair.validate_can_send_from_client('hello world', '1: client -> server')
+    pair.validate_can_send_from_server('hello world', '1: server -> client')
+    pair.validate_closing_client_closes_server('closing client')
+    pair.cleanup()
+
+    print_ok("OK")
+  finally:
+    terminate(ghostunnel)

--- a/tls.go
+++ b/tls.go
@@ -23,10 +23,17 @@ import (
 	"io/ioutil"
 	"os"
 	"sync/atomic"
+	"time"
 	"unsafe"
 
 	certigo "github.com/square/certigo/lib"
 )
+
+type timeoutError struct{}
+
+func (timeoutError) Error() string   { return "tls: DialWithDialer timed out" }
+func (timeoutError) Timeout() bool   { return true }
+func (timeoutError) Temporary() bool { return true }
 
 // certificate wraps a TLS certificate in a reloadable way
 type certificate struct {
@@ -102,6 +109,41 @@ func caBundle(caBundlePath string) (*x509.CertPool, error) {
 	bundle := x509.NewCertPool()
 	bundle.AppendCertsFromPEM(caBundleBytes)
 	return bundle, nil
+}
+
+// Internal copy of tls.DialWithDialer, adapter so it can work with HTTP CONNECT dialers.
+// See: https://golang.org/pkg/crypto/tls/#DialWithDialer
+func dialWithDialer(dialer Dialer, timeout time.Duration, network, addr string, config *tls.Config) (*tls.Conn, error) {
+	var errChannel chan error
+	if timeout != 0 {
+		errChannel = make(chan error, 2)
+		time.AfterFunc(timeout, func() {
+			errChannel <- timeoutError{}
+		})
+	}
+
+	rawConn, err := dialer.Dial(network, addr)
+	if err != nil {
+		return nil, err
+	}
+
+	conn := tls.Client(rawConn, config)
+	if timeout == 0 {
+		err = conn.Handshake()
+	} else {
+		go func() {
+			errChannel <- conn.Handshake()
+		}()
+
+		err = <-errChannel
+	}
+
+	if err != nil {
+		rawConn.Close()
+		return nil, err
+	}
+
+	return conn, nil
 }
 
 // buildConfig reads command-line options and builds a tls.Config

--- a/vendor/github.com/mwitkow/go-http-dialer/LICENSE
+++ b/vendor/github.com/mwitkow/go-http-dialer/LICENSE
@@ -1,0 +1,201 @@
+                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/mwitkow/go-http-dialer/auth.go
+++ b/vendor/github.com/mwitkow/go-http-dialer/auth.go
@@ -1,0 +1,55 @@
+// Copyright 2016 Michal Witkowski. All Rights Reserved.
+// See LICENSE for licensing terms.
+
+package http_dialer
+
+import "encoding/base64"
+
+const (
+	hdrProxyAuthResp = "Proxy-Authorization"
+	hdrProxyAuthReq = "Proxy-Authenticate"
+)
+
+// ProxyAuthorization allows for plugging in arbitrary implementations of the "Proxy-Authorization" handler.
+type ProxyAuthorization interface {
+	// Type represents what kind of Authorization, e.g. "Bearer", "Token", "Digest".
+	Type() string
+
+	// Initial allows you to specify an a-priori "Proxy-Authenticate" response header, attached to first request,
+	// so you don't need to wait for an additional challenge. If empty string is returned, "Proxy-Authenticate"
+	// header is added.
+	InitialResponse() string
+
+	// ChallengeResponse returns the content of the "Proxy-Authenticate" response header, that has been chose as
+	// response to "Proxy-Authorization" request header challenge.
+	ChallengeResponse(challenge string) string
+}
+
+type basicAuth struct {
+	username string
+	password string
+}
+
+// AuthBasic returns a ProxyAuthorization that implements "Basic" protocol while ignoring realm challanges.
+func AuthBasic(username string, password string) ProxyAuthorization {
+	return &basicAuth{username: username, password: password}
+}
+
+func (b *basicAuth) Type() string {
+	return "Basic"
+}
+
+func (b *basicAuth) InitialResponse() string {
+	return b.authString()
+}
+
+func (b *basicAuth) ChallengeResponse(challenge string) string {
+	// challenge can be realm="proxy.com"
+	// TODO(mwitkow): Implement realm lookup in AuthBasicWithRealm.
+	return b.authString()
+}
+
+func (b *basicAuth) authString() string {
+	resp := b.username + ":" + b.password
+	return base64.StdEncoding.EncodeToString([]byte(resp))
+}

--- a/vendor/github.com/mwitkow/go-http-dialer/dialer.go
+++ b/vendor/github.com/mwitkow/go-http-dialer/dialer.go
@@ -1,0 +1,158 @@
+// Copyright 2016 Michal Witkowski. All Rights Reserved.
+// See LICENSE for licensing terms.
+
+// Package http_dialer provides HTTP(S) CONNECT tunneling net.Dialer. It allows you to
+// establish arbitrary TCP connections (as long as your proxy allows them) through a HTTP(S) CONNECT point.
+package http_dialer
+
+import (
+	"bufio"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+type opt func(*HttpTunnel)
+
+// New constructs an HttpTunnel to be used a net.Dial command.
+// The first parameter is a proxy URL, for example https://foo.example.com:9090 will use foo.example.com as proxy on
+// port 9090 using TLS for connectivity.
+// Optional customization parameters are available, e.g.: WithTls, WithDialer, WithConnectionTimeout
+func New(proxyUrl *url.URL, opts ...opt) *HttpTunnel {
+	t := &HttpTunnel{
+		parentDialer: &net.Dialer{},
+	}
+	t.parseProxyUrl(proxyUrl)
+	for _, opt := range opts {
+		opt(t)
+	}
+	return t
+}
+
+// WithTls sets the tls.Config to be used (e.g. CA certs) when connecting to an HTTP proxy over TLS.
+func WithTls(tlsConfig *tls.Config) opt {
+	return func(t *HttpTunnel) {
+		t.tlsConfig = tlsConfig
+	}
+}
+
+// WithDialer allows the customization of the underlying net.Dialer used for establishing TCP connections to the proxy.
+func WithDialer(dialer *net.Dialer) opt {
+	return func(t *HttpTunnel) {
+		t.parentDialer = dialer
+	}
+}
+
+// WithConnectionTimeout customizes the underlying net.Dialer.Timeout.
+func WithConnectionTimeout(timeout time.Duration) opt {
+	return func(t *HttpTunnel) {
+		t.parentDialer.Timeout = timeout
+	}
+}
+
+// WithProxyAuth allows you to add ProxyAuthorization to calls.
+func WithProxyAuth(auth ProxyAuthorization) opt {
+	return func(t *HttpTunnel) {
+		t.auth = auth
+	}
+}
+
+// HttpTunnel represents a configured HTTP Connect Tunnel dialer.
+type HttpTunnel struct {
+	parentDialer *net.Dialer
+	isTls        bool
+	proxyAddr    string
+	tlsConfig    *tls.Config
+	auth         ProxyAuthorization
+}
+
+func (t *HttpTunnel) parseProxyUrl(proxyUrl *url.URL) {
+	t.proxyAddr = proxyUrl.Host
+	if strings.ToLower(proxyUrl.Scheme) == "https" {
+		if !strings.Contains(t.proxyAddr, ":") {
+			t.proxyAddr = t.proxyAddr + ":443"
+		}
+		t.isTls = true
+	} else {
+		if !strings.Contains(t.proxyAddr, ":") {
+			t.proxyAddr = t.proxyAddr + ":8080"
+		}
+		t.isTls = false
+	}
+}
+
+func (t *HttpTunnel) dialProxy() (net.Conn, error) {
+	if !t.isTls {
+		return t.parentDialer.Dial("tcp", t.proxyAddr)
+	}
+	return tls.DialWithDialer(t.parentDialer, "tcp", t.proxyAddr, t.tlsConfig)
+}
+
+// Dial is an implementation of net.Dialer, and returns a TCP connection handle to the host that HTTP CONNECT reached.
+func (t *HttpTunnel) Dial(network string, address string) (net.Conn, error) {
+	if network != "tcp" {
+		return nil, fmt.Errorf("network type '%v' unsupported (only 'tcp')", network)
+	}
+	conn, err := t.dialProxy()
+	if err != nil {
+		return nil, fmt.Errorf("http_tunnel: failed dialing to proxy: %v", err)
+	}
+	req := &http.Request{
+		Method: "CONNECT",
+		URL:    &url.URL{Opaque: address},
+		Host:   address, // This is weird
+		Header: make(http.Header),
+	}
+	if t.auth != nil && t.auth.InitialResponse() != "" {
+		req.Header.Set(hdrProxyAuthResp, t.auth.Type() + " " + t.auth.InitialResponse())
+	}
+	resp, err := t.doRoundtrip(conn, req)
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+	// Retry request with auth, if available.
+	if resp.StatusCode == http.StatusProxyAuthRequired && t.auth != nil {
+		responseHdr, err := t.performAuthChallengeResponse(resp)
+		if err != nil {
+			conn.Close()
+			return nil, err
+		}
+		req.Header.Set(hdrProxyAuthResp, t.auth.Type() + " " + responseHdr)
+		resp, err = t.doRoundtrip(conn, req)
+		if err != nil {
+			conn.Close()
+			return nil, err
+		}
+	}
+
+	if resp.StatusCode != 200 {
+		conn.Close()
+		return nil, fmt.Errorf("http_tunnel: failed proxying %d: %s", resp.StatusCode, resp.Status)
+	}
+	return conn, nil
+}
+
+func (t *HttpTunnel) doRoundtrip(conn net.Conn, req *http.Request) (*http.Response, error) {
+	if err := req.Write(conn); err != nil {
+		return nil, fmt.Errorf("http_tunnel: failed writing request: %v", err)
+	}
+	// Doesn't matter, discard this bufio.
+	br := bufio.NewReader(conn)
+	return http.ReadResponse(br, req)
+
+}
+
+func (t *HttpTunnel) performAuthChallengeResponse(resp *http.Response) (string, error) {
+	respAuthHdr := resp.Header.Get(hdrProxyAuthReq)
+	if !strings.Contains(respAuthHdr, t.auth.Type() + " ") {
+		return "", fmt.Errorf("http_tunnel: expected '%v' Proxy authentication, got: '%v'", t.auth.Type(), respAuthHdr)
+	}
+	splits := strings.SplitN(respAuthHdr, " ", 2)
+	challenge := splits[1]
+	return t.auth.ChallengeResponse(challenge), nil
+}

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -34,6 +34,14 @@
 			"notests": true
 		},
 		{
+			"importpath": "github.com/mwitkow/go-http-dialer",
+			"repository": "https://github.com/mwitkow/go-http-dialer",
+			"vcs": "git",
+			"revision": "378f744fb2b81a6b96e3f40cde4f3bcab5a9cff0",
+			"branch": "master",
+			"notests": true
+		},
+		{
 			"importpath": "github.com/rcrowley/go-metrics",
 			"repository": "https://github.com/rcrowley/go-metrics",
 			"vcs": "git",


### PR DESCRIPTION
Add HTTP CONNECT proxy support to ghostunnel. Set the new connect-proxy flag and ghostunnel will establish TCP connections through the proxy instead of directly. 