### PR TITLE
Better process management

### DIFF
--- a/procattr_generic.go
+++ b/procattr_generic.go
@@ -1,0 +1,11 @@
+// +build !linux
+
+package main
+
+import "syscall"
+
+func sysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{
+		Setpgid: true, // Create new process group
+	}
+}

--- a/procattr_linux.go
+++ b/procattr_linux.go
@@ -1,0 +1,20 @@
+// +build linux
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+func sysProcAttr() *syscall.SysProcAttr {
+	attr := &syscall.SysProcAttr{
+		Setpgid: true, // Create new process group
+	}
+	if os.Getpid() != 1 {
+		// Send TERM to child if parent exits
+		// See https://github.com/golang/go/issues/9263 for explanation on PID restriction
+		attr.Pdeathsig = syscall.SIGTERM
+	}
+	return attr
+}

--- a/signals.go
+++ b/signals.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	ctx "context"
 	"io"
 	"os"
 	"os/signal"
@@ -43,7 +44,7 @@ func (context *Context) signalHandler(proxy *proxy, closeables []io.Closer) {
 
 				// Best-effort graceful shutdown of status listener
 				if context.statusHTTP != nil {
-					go context.statusHTTP.Shutdown(nil)
+					go context.statusHTTP.Shutdown(ctx.Background())
 				}
 
 				// Force-exit after timeout (but make sure we terminate child)

--- a/tests/child-process-sigterm-trap.py
+++ b/tests/child-process-sigterm-trap.py
@@ -8,16 +8,16 @@ signal.signal(signal.SIGTERM, signal.SIG_IGN)
 
 # Start a server that listens for incoming connections
 try:
-    print_ok("child starting up on port %s" % sys.argv[1])
-    s = TcpServer(int(sys.argv[1]))
-    s.listen()
-    while True:
-        try:
-            s.socket, _ = s.listener.accept()
-            s.socket.settimeout(TIMEOUT)
-        except:
-            pass
+  print_ok("child starting up on port %s" % sys.argv[1])
+  s = TcpServer(int(sys.argv[1]))
+  s.listen()
+  while True:
+    try:
+      s.socket, _ = s.listener.accept()
+      s.socket.settimeout(TIMEOUT)
+    except:
+      pass
 finally:
-    s.cleanup()
+  s.cleanup()
 
 print_ok("child exiting")

--- a/tests/child-process-waits-forever.py
+++ b/tests/child-process-waits-forever.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+
+from common import *
+import time
+
+# Start a server that listens for incoming connections
+print_ok("child starting up")
+while True:
+  time.sleep(60)
+print_ok("child exiting")

--- a/tests/test-server-shutdown-sigchld.py
+++ b/tests/test-server-shutdown-sigchld.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+from subprocess import Popen
+from common import *
+import socket, ssl, time, os, signal
+
+if __name__ == "__main__":
+  ghostunnel = None
+  try:
+    # create certs
+    root = RootCert('root')
+    root.create_signed_cert('server')
+    root.create_signed_cert('client')
+
+    # start ghostunnel
+    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
+      '--target={0}:{1}'.format(LOCALHOST, STATUS_PORT), '--keystore=server.p12',
+      '--cacert=root.crt', '--allow-ou=client', '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
+      '--', 'python3', 'child-process-waits-forever.py'])
+
+    # wait for startup
+    TlsClient(None, 'root', STATUS_PORT).connect(20, 'server')
+
+    # get child pid
+    urlopen = lambda path: urllib.request.urlopen(path, cafile='root.crt')
+    status = json.loads(str(urlopen("https://{0}:{1}/_status".format(LOCALHOST, STATUS_PORT)).read(), 'utf-8'))
+
+    # shut down ghostunnel with connection open, make sure it doesn't hang
+    print_ok('terminating child via signal')
+    for n in range(0, 90):
+      try:
+        try:
+          os.kill(status['child_pid'], signal.SIGTERM)
+          ghostunnel.wait(timeout=1)
+        except:
+          pass
+        os.kill(ghostunnel.pid, 0)
+        print_ok("ghostunnel is still alive")
+      except:
+        stopped = True
+        break
+      time.sleep(1)
+
+    if not stopped:
+      raise Exception('ghostunnel did not terminate within 90 seconds')
+
+    print_ok("OK (terminated)")
+  finally:
+    terminate(ghostunnel)
+      


### PR DESCRIPTION
Better process management:
* When executing child process, create new process group. This allows us to send signals to all child processes instead of just our direct descendant.
* Set Pdeathsig on Linux to send SIGTERM to child if ghostunnel exists. This avoids child processes being orphaned in case of e.g. a bug in ghostunnel that causes it to exit without terminating the child process. 
* Signal handler to forward signals to child process group. If ghostunnel receives a SIGTERM, we forward and send SIGTERM to child process group to tell it to shut down. 
* Handle SIGCHLD in main signal handler, to get ghostunnel to shut down if the child exits. Previously ghostunnel was just blocking on waitpid() and ignoring SIGCHLD. 

Note that this doesn't clean up any processes that are orphaned and given to ghostunnel, e.g. if ghostunnel is running as PID 1 in a container. I don't think ghostunnel should be used for that purpose, something like dumb-init already solves that problem. This is just to make the process management more robust when using ghostunnel on a shared system e.g. under runit (runit doesn't take care of orphaned processes).   