### PR TITLE
Replace listen/target flags with proxy flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,7 @@ Start a backend server:
 Start a ghostunnel in server mode to proxy connections:
 
     ghostunnel server \
-        --listen localhost:8443 \
-        --target localhost:8080 \
+        --proxy localhost:8443:localhost:8080 \
         --keystore test-keys/server.p12 \
         --cacert test-keys/root.crt \
         --allow-cn client
@@ -154,8 +153,7 @@ Start a backend TLS server:
 Start a ghostunnel with a client certificate to forward connections:
 
     ghostunnel client \
-        --listen localhost:8080 \
-        --target localhost:8443 \
+        --proxy localhost:8080:localhost:8443 \
         --keystore test-keys/client.p12 \
         --cacert test-keys/root.crt
 
@@ -178,8 +176,7 @@ Start netcat on port `8001`:
 Start the ghostunnel server:
 
     ghostunnel server \
-        --listen localhost:8002 \
-        --target localhost:8001 \
+        --proxy localhost:8002:localhost:8001 \
         --keystore test-keys/server.p12 \
         --cacert test-keys/root.crt \
         --allow-cn client
@@ -187,8 +184,7 @@ Start the ghostunnel server:
 Start the ghostunnel client:
 
     ghostunnel client \
-        --listen localhost:8003 \
-        --target localhost:8002 \
+        --proxy localhost:8003:localhost:8002 \
         --keystore test-keys/client.p12 \
         --cacert test-keys/root.crt
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ Start a backend server:
 Start a ghostunnel in server mode to proxy connections:
 
     ghostunnel server \
-        --proxy localhost:8443:localhost:8080 \
+        --listen localhost:8443 \
+        --target localhost:8080 \
         --keystore test-keys/server.p12 \
         --cacert test-keys/root.crt \
         --allow-cn client
@@ -153,7 +154,8 @@ Start a backend TLS server:
 Start a ghostunnel with a client certificate to forward connections:
 
     ghostunnel client \
-        --proxy localhost:8080:localhost:8443 \
+        --listen localhost:8080 \
+        --target localhost:8443 \
         --keystore test-keys/client.p12 \
         --cacert test-keys/root.crt
 
@@ -176,7 +178,8 @@ Start netcat on port `8001`:
 Start the ghostunnel server:
 
     ghostunnel server \
-        --proxy localhost:8002:localhost:8001 \
+        --listen localhost:8002 \
+        --target localhost:8001 \
         --keystore test-keys/server.p12 \
         --cacert test-keys/root.crt \
         --allow-cn client
@@ -184,7 +187,8 @@ Start the ghostunnel server:
 Start the ghostunnel client:
 
     ghostunnel client \
-        --proxy localhost:8003:localhost:8002 \
+        --listen localhost:8003 \
+        --target localhost:8002 \
         --keystore test-keys/client.p12 \
         --cacert test-keys/root.crt
 

--- a/main.go
+++ b/main.go
@@ -48,20 +48,24 @@ var (
 var (
 	app = kingpin.New("ghostunnel", "A simple SSL/TLS proxy with mutual authentication for securing non-TLS services.")
 
-	serverCommand      = app.Command("server", "Server mode (TLS listener -> plain TCP/UNIX target).")
-	serverProxyStanza  = serverCommand.Flag("proxy", "Proxy stanza (SOURCE:TARGET, e.g. localhost:443:localhost:80).").PlaceHolder("STANZA").Required().String()
-	serverUnsafeTarget = serverCommand.Flag("unsafe-target", "If set, does not limit target to localhost, 127.0.0.1, [::1], or UNIX sockets.").Bool()
-	serverAllowAll     = serverCommand.Flag("allow-all", "Allow all clients, do not check client cert subject.").Bool()
-	serverAllowedCNs   = serverCommand.Flag("allow-cn", "Allow clients with given common name (can be repeated).").PlaceHolder("CN").Strings()
-	serverAllowedOUs   = serverCommand.Flag("allow-ou", "Allow clients with given organizational unit name (can be repeated).").PlaceHolder("OU").Strings()
-	serverAllowedDNSs  = serverCommand.Flag("allow-dns-san", "Allow clients with given DNS subject alternative name (can be repeated).").PlaceHolder("SAN").Strings()
-	serverAllowedIPs   = serverCommand.Flag("allow-ip-san", "Allow clients with given IP subject alternative name (can be repeated).").PlaceHolder("SAN").IPList()
+	serverCommand        = app.Command("server", "Server mode (TLS listener -> plain TCP/UNIX target).")
+	serverListenAddress  = serverCommand.Flag("listen", "Address and port to listen on (HOST:PORT).").PlaceHolder("ADDR").String()
+	serverForwardAddress = serverCommand.Flag("target", "Address to forward connections to (HOST:PORT, or unix:PATH).").PlaceHolder("ADDR").String()
+	serverProxyStanza    = serverCommand.Flag("proxy", "Proxy stanza (SOURCE:TARGET, e.g. localhost:443:localhost:80).").PlaceHolder("STANZA").String()
+	serverUnsafeTarget   = serverCommand.Flag("unsafe-target", "If set, does not limit target to localhost, 127.0.0.1, [::1], or UNIX sockets.").Bool()
+	serverAllowAll       = serverCommand.Flag("allow-all", "Allow all clients, do not check client cert subject.").Bool()
+	serverAllowedCNs     = serverCommand.Flag("allow-cn", "Allow clients with given common name (can be repeated).").PlaceHolder("CN").Strings()
+	serverAllowedOUs     = serverCommand.Flag("allow-ou", "Allow clients with given organizational unit name (can be repeated).").PlaceHolder("OU").Strings()
+	serverAllowedDNSs    = serverCommand.Flag("allow-dns-san", "Allow clients with given DNS subject alternative name (can be repeated).").PlaceHolder("SAN").Strings()
+	serverAllowedIPs     = serverCommand.Flag("allow-ip-san", "Allow clients with given IP subject alternative name (can be repeated).").PlaceHolder("SAN").IPList()
 
-	clientCommand      = app.Command("client", "Client mode (plain TCP/UNIX listener -> TLS target).")
-	clientProxyStanza  = clientCommand.Flag("proxy", "Proxy stanza (SOURCE:TARGET, e.g. localhost:443:localhost:80).").PlaceHolder("STANZA").Required().String()
-	clientUnsafeListen = clientCommand.Flag("unsafe-listen", "If set, does not limit listen to localhost, 127.0.0.1, [::1], or UNIX sockets.").Bool()
-	clientServerName   = clientCommand.Flag("override-server-name", "If set, overrides the server name used for hostname verification.").PlaceHolder("NAME").String()
-	clientConnectProxy = clientCommand.Flag("connect-proxy", "If set, connect to target over given HTTP CONNECT proxy. Must be HTTP/HTTPS URL.").PlaceHolder("URL").URL()
+	clientCommand        = app.Command("client", "Client mode (plain TCP/UNIX listener -> TLS target).")
+	clientListenAddress  = clientCommand.Flag("listen", "Address and port to listen on (HOST:PORT, or unix:PATH).").PlaceHolder("ADDR").String()
+	clientForwardAddress = clientCommand.Flag("target", "Address to forward connections to (HOST:PORT).").PlaceHolder("ADDR").String()
+	clientProxyStanza    = clientCommand.Flag("proxy", "Proxy stanza (SOURCE:TARGET, e.g. localhost:443:localhost:80).").PlaceHolder("STANZA").String()
+	clientUnsafeListen   = clientCommand.Flag("unsafe-listen", "If set, does not limit listen to localhost, 127.0.0.1, [::1], or UNIX sockets.").Bool()
+	clientServerName     = clientCommand.Flag("override-server-name", "If set, overrides the server name used for hostname verification.").PlaceHolder("NAME").String()
+	clientConnectProxy   = clientCommand.Flag("connect-proxy", "If set, connect to target over given HTTP CONNECT proxy. Must be HTTP/HTTPS URL.").PlaceHolder("URL").URL()
 
 	keystorePath        = app.Flag("keystore", "Path to certificate and keystore (PEM, PKCS12).").PlaceHolder("PATH").Required().String()
 	keystorePass        = app.Flag("storepass", "Password for certificate and keystore (optional).").PlaceHolder("PASS").String()
@@ -135,31 +139,49 @@ func validateUnixOrLocalhost(addr addressData) bool {
 
 // Validate flags for server mode
 func serverValidateFlags() error {
+	if (*serverListenAddress != "" || *serverForwardAddress != "") && (*serverProxyStanza != "") {
+		return errors.New("--listen/--target and --proxy are mutually exclusive")
+	}
 	if !(*serverAllowAll) && len(*serverAllowedCNs) == 0 && len(*serverAllowedOUs) == 0 && len(*serverAllowedDNSs) == 0 && len(*serverAllowedIPs) == 0 {
-		return fmt.Errorf("at least one of --allow-all, --allow-cn, --allow-ou, --allow-dns-san or --allow-ip-san is required")
+		return errors.New("at least one of --allow-all, --allow-cn, --allow-ou, --allow-dns-san or --allow-ip-san is required")
 	}
 	if *serverAllowAll && (len(*serverAllowedCNs) > 0 || len(*serverAllowedOUs) > 0 || len(*serverAllowedDNSs) > 0 || len(*serverAllowedIPs) > 0) {
-		return fmt.Errorf("--allow-all and other access control flags are mutually exclusive")
+		return errors.New("--allow-all and other access control flags are mutually exclusive")
 	}
 
-	_, target, err := parseProxyStanza(*serverProxyStanza)
+	var err error
+	var target addressData
+	if *serverProxyStanza != "" {
+		_, target, err = parseProxyStanza(*serverProxyStanza)
+	} else {
+		target, err = parseUnixOrTCPAddress(*serverForwardAddress)
+	}
 	if err != nil {
 		return err
 	}
 	if !*serverUnsafeTarget && !validateUnixOrLocalhost(target) {
-		return fmt.Errorf("proxy target must be unix:PATH, localhost:PORT, 127.0.0.1:PORT or [::1]:PORT (unless --unsafe-target is set)")
+		return errors.New("proxy target must be unix:PATH, localhost:PORT, 127.0.0.1:PORT or [::1]:PORT (unless --unsafe-target is set)")
 	}
 	return nil
 }
 
 // Validate flags for client mode
 func clientValidateFlags() error {
-	source, _, err := parseProxyStanza(*clientProxyStanza)
+	if (*clientListenAddress != "" || *clientForwardAddress != "") && (*clientProxyStanza != "") {
+		return errors.New("--listen/--target and --proxy are mutually exclusive")
+	}
+	var err error
+	var source addressData
+	if *clientProxyStanza != "" {
+		source, _, err = parseProxyStanza(*clientProxyStanza)
+	} else {
+		source, err = parseUnixOrTCPAddress(*clientListenAddress)
+	}
 	if err != nil {
 		return err
 	}
 	if !*clientUnsafeListen && !validateUnixOrLocalhost(source) {
-		return fmt.Errorf("proxy source must be unix:PATH, localhost:PORT, 127.0.0.1:PORT or [::1]:PORT (unless --unsafe-listen is set)")
+		return errors.New("proxy source must be unix:PATH, localhost:PORT, 127.0.0.1:PORT or [::1]:PORT (unless --unsafe-listen is set)")
 	}
 	return nil
 }
@@ -226,10 +248,26 @@ func run(args []string) error {
 		}
 		logger.Printf("starting ghostunnel in server mode")
 
-		source, target, err := parseProxyStanza(*serverProxyStanza)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "error: invalid proxy stanza: %s\n", err)
-			return err
+		var err error
+		var source, target addressData
+		if *serverProxyStanza != "" {
+			source, target, err = parseProxyStanza(*serverProxyStanza)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "error: invalid proxy stanza: %s\n", err)
+				return err
+			}
+		} else {
+			source, err = parseUnixOrTCPAddress(*serverListenAddress)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "error: invalid listen address: %s\n", err)
+				return err
+			}
+
+			target, err = parseUnixOrTCPAddress(*serverForwardAddress)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "error: invalid forward address: %s\n", err)
+				return err
+			}
 		}
 
 		dial, err := serverBackendDialer(target)
@@ -255,10 +293,26 @@ func run(args []string) error {
 		}
 		logger.Printf("starting ghostunnel in client mode")
 
-		source, target, err := parseProxyStanza(*clientProxyStanza)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "error: invalid proxy stanza: %s\n", err)
-			return err
+		var err error
+		var source, target addressData
+		if *clientProxyStanza != "" {
+			source, target, err = parseProxyStanza(*clientProxyStanza)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "error: invalid proxy stanza: %s\n", err)
+				return err
+			}
+		} else {
+			source, err = parseUnixOrTCPAddress(*clientListenAddress)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "error: invalid listen address: %s\n", err)
+				return err
+			}
+
+			target, err = parseUnixOrTCPAddress(*clientForwardAddress)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "error: invalid forward address: %s\n", err)
+				return err
+			}
 		}
 
 		dial, err := clientBackendDialer(cert, target)

--- a/net.go
+++ b/net.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"crypto/tls"
+	"fmt"
 	"io"
 	"net"
 	"strings"
@@ -33,6 +34,10 @@ type proxy struct {
 	listener net.Listener
 	handlers *sync.WaitGroup
 	dial     func() (net.Conn, error)
+}
+
+type addressData struct {
+	network, address, host string
 }
 
 var (
@@ -134,17 +139,41 @@ func copyData(dst net.Conn, src net.Conn) {
 	}
 }
 
-// Parse a string representing a TCP address or UNIX socket for our backend
-// target. The input can be or the form "HOST:PORT" for TCP or "unix:PATH"
-// for a UNIX socket.
-func parseUnixOrTCPAddress(input string) (network, address, host string, err error) {
-	if strings.HasPrefix(input, "unix:") {
-		network = "unix"
-		address = input[5:]
+// Parse a proxy stanza string of the form SOURCE:TARGET, where both SOURCE and/or
+// target can be HOST:PORT (TCP) or unix:PATH (UNIX domain socket).
+func parseProxyStanza(input string) (source, target addressData, err error) {
+	components := strings.Split(input, ":")
+	if len(components) != 4 {
+		err = fmt.Errorf("invalid proxy stanza: %s", input)
 		return
 	}
 
-	host, _, err = net.SplitHostPort(input)
+	sourceRaw := fmt.Sprintf("%s:%s", components[0], components[1])
+	source, err = parseUnixOrTCPAddress(sourceRaw)
+	if err != nil {
+		return
+	}
+
+	targetRaw := fmt.Sprintf("%s:%s", components[2], components[3])
+	target, err = parseUnixOrTCPAddress(targetRaw)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// Parse a string representing a TCP address or UNIX socket for our backend
+// target. The input can be or the form "HOST:PORT" for TCP or "unix:PATH"
+// for a UNIX socket.
+func parseUnixOrTCPAddress(input string) (addr addressData, err error) {
+	if strings.HasPrefix(input, "unix:") {
+		addr.network = "unix"
+		addr.address = input[5:]
+		return
+	}
+
+	addr.host, _, err = net.SplitHostPort(input)
 	if err != nil {
 		return
 	}
@@ -155,6 +184,6 @@ func parseUnixOrTCPAddress(input string) (network, address, host string, err err
 		return
 	}
 
-	network, address = "tcp", tcp.String()
+	addr.network, addr.address = "tcp", tcp.String()
 	return
 }

--- a/net_test.go
+++ b/net_test.go
@@ -23,32 +23,32 @@ import (
 )
 
 func TestParseUnixOrTcpAddress(t *testing.T) {
-	network, address, host, _ := parseUnixOrTCPAddress("unix:/tmp/foo")
-	if network != "unix" {
-		t.Errorf("unexpected network: %s", network)
+	addr, _ := parseUnixOrTCPAddress("unix:/tmp/foo")
+	if addr.network != "unix" {
+		t.Errorf("unexpected network: %s", addr.network)
 	}
-	if address != "/tmp/foo" {
-		t.Errorf("unexpected address: %s", address)
+	if addr.address != "/tmp/foo" {
+		t.Errorf("unexpected address: %s", addr.address)
 	}
-	if host != "" {
-		t.Errorf("unexpected host: %s", host)
+	if addr.host != "" {
+		t.Errorf("unexpected host: %s", addr.host)
 	}
 
-	network, address, host, _ = parseUnixOrTCPAddress("localhost:8080")
+	addr, _ = parseUnixOrTCPAddress("localhost:8080")
 	// note: ipv6 test is probably fragile, we don't expand ::1.
-	if network != "tcp" {
-		t.Errorf("unexpected network: %s", network)
+	if addr.network != "tcp" {
+		t.Errorf("unexpected network: %s", addr.network)
 	}
-	if address != "127.0.0.1:8080" && address != "[::1]:8080" {
-		t.Errorf("unexpected address: %s", address)
+	if addr.address != "127.0.0.1:8080" && addr.address != "[::1]:8080" {
+		t.Errorf("unexpected address: %s", addr.address)
 	}
-	if host != "localhost" {
-		t.Errorf("unexpected host: %s", host)
+	if addr.host != "localhost" {
+		t.Errorf("unexpected host: %s", addr.host)
 	}
 
-	_, _, _, err := parseUnixOrTCPAddress("localhost")
+	_, err := parseUnixOrTCPAddress("localhost")
 	assert.NotNil(t, err, "was able to parse invalid host/port")
 
-	_, _, _, err = parseUnixOrTCPAddress("256.256.256.256:99999")
+	_, err = parseUnixOrTCPAddress("256.256.256.256:99999")
 	assert.NotNil(t, err, "was able to parse invalid host/port")
 }

--- a/tests/test-client-auto-reload-certificate.py
+++ b/tests/test-client-auto-reload-certificate.py
@@ -24,9 +24,11 @@ if __name__ == "__main__":
     root2.create_signed_cert('server2')
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['client', '--listen={0}:13001'.format(LOCALHOST),
-      '--target={0}:13002'.format(LOCALHOST), '--keystore=client1.p12',
-      '--timed-reload=1s', '--cacert=root1.crt',
+    ghostunnel = run_ghostunnel(['client',
+      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
+      '--keystore=client1.p12',
+      '--timed-reload=1s',
+      '--cacert=root1.crt',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
     # ensure ghostunnel connects with server1

--- a/tests/test-client-concurrent-connections.py
+++ b/tests/test-client-concurrent-connections.py
@@ -37,10 +37,11 @@ if __name__ == "__main__":
       root.create_signed_cert("server{0}".format(i))
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['client', '--listen={0}:13001'.format(LOCALHOST),
-      '--target={0}:13002'.format(LOCALHOST), '--keystore=client.p12',
-      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
-      '--cacert=root.crt'])
+    ghostunnel = run_ghostunnel(['client',
+      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
+      '--keystore=client.p12',
+      '--cacert=root.crt',
+      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
     # servers should be able to communicate all at the same time.
     proc = []

--- a/tests/test-client-handles-client-closes-connection.py
+++ b/tests/test-client-handles-client-closes-connection.py
@@ -16,10 +16,11 @@ if __name__ == "__main__":
     root.create_signed_cert('client')
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['client', '--listen={0}:13001'.format(LOCALHOST),
-      '--target={0}:13002'.format(LOCALHOST), '--keystore=client.p12',
-      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
-      '--cacert=root.crt'])
+    ghostunnel = run_ghostunnel(['client',
+      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
+      '--keystore=client.p12',
+      '--cacert=root.crt',
+      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
     # connect to server, confirm that the tunnel is up
     pair = SocketPair(TcpClient(13001), TlsServer('server', 'root', 13002))

--- a/tests/test-client-handles-no-server.py
+++ b/tests/test-client-handles-no-server.py
@@ -16,9 +16,11 @@ if __name__ == "__main__":
     root.create_signed_cert('client')
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['client', '--listen={0}:13001'.format(LOCALHOST),
-      '--target={0}:13002'.format(LOCALHOST), '--keystore=client.p12',
-      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT), '--cacert=root.crt'])
+    ghostunnel = run_ghostunnel(['client',
+      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
+      '--keystore=client.p12',
+      '--cacert=root.crt',
+      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
     # client should fail to connect since nothing is listening on 13003
     try:

--- a/tests/test-client-handles-server-closes-connection.py
+++ b/tests/test-client-handles-server-closes-connection.py
@@ -16,9 +16,11 @@ if __name__ == "__main__":
     root.create_signed_cert('client')
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['client', '--listen={0}:13001'.format(LOCALHOST),
-      '--target={0}:13002'.format(LOCALHOST), '--keystore=client.p12',
-      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT), '--cacert=root.crt'])
+    ghostunnel = run_ghostunnel(['client',
+      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
+      '--keystore=client.p12',
+      '--cacert=root.crt',
+      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
     # connect with client, confirm that the tunnel is up
     pair = SocketPair(TcpClient(13001), TlsServer('server', 'root', 13002))

--- a/tests/test-client-metrics-bridge.py
+++ b/tests/test-client-metrics-bridge.py
@@ -27,9 +27,11 @@ if __name__ == "__main__":
     server.start()
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['client', '--listen={0}:13001'.format(LOCALHOST),
-      '--target={0}:13002'.format(LOCALHOST), '--keystore=client.p12',
-      '--cacert=root.crt', '--metrics-interval=1s',
+    ghostunnel = run_ghostunnel(['client',
+      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
+      '--keystore=client.p12',
+      '--cacert=root.crt',
+      '--metrics-interval=1s',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
       '--metrics-url=http://localhost:13080/post'])
 

--- a/tests/test-client-metrics-graphite.py
+++ b/tests/test-client-metrics-graphite.py
@@ -21,10 +21,13 @@ if __name__ == "__main__":
     m.listen(1)
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['client', '--listen={0}:13001'.format(LOCALHOST),
-      '--target={0}:13002'.format(LOCALHOST), '--keystore=client.p12',
-      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT), '--metrics-interval=1s',
-      '--cacert=root.crt', '--graphite=localhost:13099'])
+    ghostunnel = run_ghostunnel(['client',
+      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
+      '--keystore=client.p12',
+      '--cacert=root.crt',
+      '--metrics-interval=1s',
+      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
+      '--graphite=localhost:13099'])
 
     # wait for metrics to be sent
     conn, addr = m.accept()

--- a/tests/test-client-override-server-name.py
+++ b/tests/test-client-override-server-name.py
@@ -20,9 +20,12 @@ if __name__ == "__main__":
     other_root.create_signed_cert('other_server')
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['client', '--listen={0}:13001'.format(LOCALHOST),
-      '--target=localhost:13002', '--keystore=client.p12', '--cacert=root.crt',
-      '--timed-reload=1s', '--override-server-name=foobar',
+    ghostunnel = run_ghostunnel(['client',
+      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
+      '--keystore=client.p12',
+      '--timed-reload=1s',
+      '--cacert=root.crt',
+      '--override-server-name=foobar',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
     # connect to server1, confirm that the tunnel is up

--- a/tests/test-client-reload-broken-certificate.py
+++ b/tests/test-client-reload-broken-certificate.py
@@ -20,9 +20,11 @@ if __name__ == "__main__":
     root1.create_signed_cert('client1')
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['client', '--listen={0}:13001'.format(LOCALHOST),
-      '--target={0}:13002'.format(LOCALHOST), '--keystore=client1.p12',
-      '--cacert=root1.crt', '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
+    ghostunnel = run_ghostunnel(['client',
+      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
+      '--keystore=client1.p12',
+      '--cacert=root1.crt',
+      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
     # ensure ghostunnel connects with server1
     pair1 = SocketPair(TcpClient(13001), TlsServer('server1', 'root1', 13002))

--- a/tests/test-client-reloads-certificate.py
+++ b/tests/test-client-reloads-certificate.py
@@ -24,9 +24,11 @@ if __name__ == "__main__":
     root2.create_signed_cert('server2')
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['client', '--listen={0}:13001'.format(LOCALHOST),
-      '--target={0}:13002'.format(LOCALHOST), '--keystore=client1.p12',
-      '--cacert=root1.crt', '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
+    ghostunnel = run_ghostunnel(['client',
+      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
+      '--keystore=client1.p12',
+      '--cacert=root1.crt',
+      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
     # ensure ghostunnel connects with server1
     pair1 = SocketPair(TcpClient(13001), TlsServer('server1', 'root1', 13002))

--- a/tests/test-client-shutdown-sigterm.py
+++ b/tests/test-client-shutdown-sigterm.py
@@ -13,9 +13,11 @@ if __name__ == "__main__":
     root.create_signed_cert('client')
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['client', '--listen={0}:13001'.format(LOCALHOST),
-      '--target={0}:13002'.format(LOCALHOST), '--keystore=client.p12',
-      '--cacert=root.crt', '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
+    ghostunnel = run_ghostunnel(['client',
+      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
+      '--keystore=client.p12',
+      '--cacert=root.crt',
+      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
     # wait for startup
     TlsClient(None, 'root', STATUS_PORT).connect(20, 'client')

--- a/tests/test-client-shutdown-timeout.py
+++ b/tests/test-client-shutdown-timeout.py
@@ -13,9 +13,11 @@ if __name__ == "__main__":
     root.create_signed_cert('client')
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['client', '--listen={0}:13001'.format(LOCALHOST),
-      '--target={0}:13002'.format(LOCALHOST), '--keystore=client.p12',
-      '--cacert=root.crt', '--shutdown-timeout=1s',
+    ghostunnel = run_ghostunnel(['client',
+      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
+      '--keystore=client.p12',
+      '--cacert=root.crt',
+      '--shutdown-timeout=1s',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
     # wait for startup

--- a/tests/test-client-status-port.py
+++ b/tests/test-client-status-port.py
@@ -16,9 +16,11 @@ if __name__ == "__main__":
 
     # start ghostunnel
     # hack: point target to STATUS_PORT so that /_status doesn't 503.
-    ghostunnel = run_ghostunnel(['client', '--listen={0}:13001'.format(LOCALHOST),
-      '--target={0}:{1}'.format(LOCALHOST, STATUS_PORT), '--keystore=client.p12',
-      '--cacert=root.crt', '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
+    ghostunnel = run_ghostunnel(['client',
+      '--proxy={0}:13001:{0}:{1}'.format(LOCALHOST, STATUS_PORT),
+      '--keystore=client.p12',
+      '--cacert=root.crt',
+      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
     urlopen = lambda path: urllib.request.urlopen(path, cafile='root.crt')
 

--- a/tests/test-client-unix-socket-backend.py
+++ b/tests/test-client-unix-socket-backend.py
@@ -16,9 +16,11 @@ if __name__ == "__main__":
 
     # start ghostunnel
     socket = UnixClient()
-    ghostunnel = run_ghostunnel(['client', '--listen=unix:{0}'.format(socket.get_socket_path()),
-      '--target={0}:13002'.format(LOCALHOST), '--keystore=client.p12',
-      '--cacert=root.crt', '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
+    ghostunnel = run_ghostunnel(['client',
+      '--proxy=unix:{0}:{1}:13002'.format(socket.get_socket_path(), LOCALHOST),
+      '--keystore=client.p12',
+      '--cacert=root.crt',
+      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
     # connect with client, confirm that the tunnel is up
     pair = SocketPair(socket, TlsServer('server', 'root', 13002))

--- a/tests/test-client-via-http-connect-proxy.py
+++ b/tests/test-client-via-http-connect-proxy.py
@@ -49,9 +49,12 @@ if __name__ == "__main__":
     server.start()
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['client', '--listen={0}:13001'.format(LOCALHOST),
-      '--target=localhost:13002', '--keystore=client.p12', '--cacert=root.crt',
-      '--connect-proxy=http://localhost:13080', '--timeout=30s',
+    ghostunnel = run_ghostunnel(['client',
+      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
+      '--keystore=client.p12',
+      '--connect-proxy=http://localhost:13080',
+      '--timeout=30s',
+      '--cacert=root.crt',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
     # connect to server, confirm that the tunnel is up

--- a/tests/test-server-auto-reload-certificate.py
+++ b/tests/test-server-auto-reload-certificate.py
@@ -16,10 +16,13 @@ if __name__ == "__main__":
     root.create_signed_cert('client')
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
-      '--target={0}:13002'.format(LOCALHOST), '--keystore=server.p12',
-      '--cacert=root.crt', '--allow-ou=client', '--timed-reload=1s',
-      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
+    ghostunnel = run_ghostunnel(['server',
+        '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
+        '--keystore=server.p12',
+        '--cacert=root.crt',
+        '--allow-ou=client',
+        '--timed-reload=1s',
+        '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
     # create connections with client
     pair1 = SocketPair(TlsClient('client', 'root', 13001), TcpServer(13002))

--- a/tests/test-server-concurrent-connections.py
+++ b/tests/test-server-concurrent-connections.py
@@ -39,8 +39,9 @@ if __name__ == "__main__":
       allow_ou.append("--allow-ou=client{0}".format(i))
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
-      '--target={0}:13002'.format(LOCALHOST), '--keystore=server.p12',
+    ghostunnel = run_ghostunnel(['server',
+      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
+      '--keystore=server.p12',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
       '--cacert=root.crt'] + allow_ou)
 

--- a/tests/test-server-handles-client-closes-connection.py
+++ b/tests/test-server-handles-client-closes-connection.py
@@ -16,10 +16,12 @@ if __name__ == "__main__":
     root.create_signed_cert('client')
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
-      '--target={0}:13002'.format(LOCALHOST), '--keystore=server.p12',
+    ghostunnel = run_ghostunnel(['server',
+      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
+      '--keystore=server.p12',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
-      '--cacert=root.crt', '--allow-ou=client'])
+      '--cacert=root.crt',
+      '--allow-ou=client'])
 
     # connect with client, confirm that the tunnel is up
     pair = SocketPair(TlsClient('client', 'root', 13001), TcpServer(13002))

--- a/tests/test-server-handles-no-server.py
+++ b/tests/test-server-handles-no-server.py
@@ -16,10 +16,12 @@ if __name__ == "__main__":
     root.create_signed_cert('client')
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
-      '--target={0}:13002'.format(LOCALHOST), '--keystore=server.p12',
+    ghostunnel = run_ghostunnel(['server',
+      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
+      '--keystore=server.p12',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
-      '--cacert=root.crt', '--allow-ou=client'])
+      '--cacert=root.crt',
+      '--allow-ou=client'])
 
     # client should fail to connect since nothing is listening on 13003
     try:

--- a/tests/test-server-handles-server-closes-connection.py
+++ b/tests/test-server-handles-server-closes-connection.py
@@ -16,10 +16,12 @@ if __name__ == "__main__":
     root.create_signed_cert('client')
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
-      '--target={0}:13000'.format(LOCALHOST), '--keystore=server.p12',
+    ghostunnel = run_ghostunnel(['server',
+      '--proxy={0}:13001:{0}:13000'.format(LOCALHOST),
+      '--keystore=server.p12',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
-      '--cacert=root.crt', '--allow-ou=client'])
+      '--cacert=root.crt',
+      '--allow-ou=client'])
 
     # connect with client, confirm that the tunnel is up
     pair = SocketPair(TlsClient('client', 'root', 13001), TcpServer(13000))

--- a/tests/test-server-metrics-bridge.py
+++ b/tests/test-server-metrics-bridge.py
@@ -27,10 +27,14 @@ if __name__ == "__main__":
     server.start()
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
-      '--target={0}:13002'.format(LOCALHOST), '--keystore=server.p12',
-      '--cacert=root.crt', '--allow-ou=client', '--enable-pprof',
-      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT), '--metrics-interval=1s',
+    ghostunnel = run_ghostunnel(['server',
+      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
+      '--keystore=server.p12',
+      '--cacert=root.crt',
+      '--allow-ou=client',
+      '--enable-pprof',
+      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
+      '--metrics-interval=1s',
       '--metrics-url=http://localhost:13080/post'])
 
     # wait for metrics to post

--- a/tests/test-server-metrics-graphite.py
+++ b/tests/test-server-metrics-graphite.py
@@ -21,9 +21,12 @@ if __name__ == "__main__":
     m.listen(1)
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
-      '--target={0}:13100'.format(LOCALHOST), '--keystore=server.p12',
-      '--cacert=root.crt', '--allow-ou=client', '--metrics-interval=1s',
+    ghostunnel = run_ghostunnel(['server',
+      '--proxy={0}:13001:{0}:13100'.format(LOCALHOST),
+      '--keystore=server.p12',
+      '--cacert=root.crt',
+      '--allow-ou=client',
+      '--metrics-interval=1s',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
       '--graphite=localhost:13099'])
 

--- a/tests/test-server-rejects-invalid-ou-or-ca.py
+++ b/tests/test-server-rejects-invalid-ou-or-ca.py
@@ -20,10 +20,12 @@ if __name__ == "__main__":
     other_root.create_signed_cert('other_client1')
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
-      '--target={0}:13002'.format(LOCALHOST), '--keystore=server.p12',
+    ghostunnel = run_ghostunnel(['server',
+      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
+      '--keystore=server.p12',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
-      '--cacert=root.crt', '--allow-ou=client1'])
+      '--cacert=root.crt',
+      '--allow-ou=client1'])
 
     # connect with client1, confirm that the tunnel is up
     pair = SocketPair(TlsClient('client1', 'root', 13001), TcpServer(13002))

--- a/tests/test-server-reload-broken-certificate.py
+++ b/tests/test-server-reload-broken-certificate.py
@@ -15,9 +15,11 @@ if __name__ == "__main__":
     root.create_signed_cert('client')
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
-      '--target={0}:13002'.format(LOCALHOST), '--keystore=server.p12',
-      '--cacert=root.crt', '--allow-ou=client',
+    ghostunnel = run_ghostunnel(['server',
+      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
+      '--keystore=server.p12',
+      '--cacert=root.crt',
+      '--allow-ou=client',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
     # create connections with client

--- a/tests/test-server-reloads-certificate.py
+++ b/tests/test-server-reloads-certificate.py
@@ -16,9 +16,11 @@ if __name__ == "__main__":
     root.create_signed_cert('client')
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
-      '--target={0}:13002'.format(LOCALHOST), '--keystore=server.p12',
-      '--cacert=root.crt', '--allow-ou=client',
+    ghostunnel = run_ghostunnel(['server',
+      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
+      '--keystore=server.p12',
+      '--cacert=root.crt',
+      '--allow-ou=client',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
     # create connections with client

--- a/tests/test-server-shutdown-sigterm.py
+++ b/tests/test-server-shutdown-sigterm.py
@@ -13,9 +13,11 @@ if __name__ == "__main__":
     root.create_signed_cert('client')
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
-      '--target={0}:13002'.format(LOCALHOST), '--keystore=server.p12',
-      '--cacert=root.crt', '--allow-ou=client',
+    ghostunnel = run_ghostunnel(['server',
+      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
+      '--keystore=server.p12',
+      '--cacert=root.crt',
+      '--allow-ou=client',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
     # wait for startup

--- a/tests/test-server-shutdown-timeout.py
+++ b/tests/test-server-shutdown-timeout.py
@@ -13,9 +13,12 @@ if __name__ == "__main__":
     root.create_signed_cert('client')
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
-      '--target={0}:13002'.format(LOCALHOST), '--keystore=server.p12',
-      '--cacert=root.crt', '--allow-ou=client', '--shutdown-timeout=1s',
+    ghostunnel = run_ghostunnel(['server',
+      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
+      '--keystore=server.p12',
+      '--cacert=root.crt',
+      '--allow-ou=client',
+      '--shutdown-timeout=1s',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
     # wait for startup

--- a/tests/test-server-status-port-unix.py
+++ b/tests/test-server-status-port-unix.py
@@ -28,9 +28,11 @@ if __name__ == "__main__":
     tempdir = mkdtemp()
     path = os.path.join(tempdir, 'ghostunnel-status-socket')
 
-    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
-      '--target=unix:{0}'.format(path), '--keystore=server.p12',
-      '--cacert=root.crt', '--allow-ou=client',
+    ghostunnel = run_ghostunnel(['server',
+      '--proxy={0}:13001:unix:{1}'.format(LOCALHOST, path),
+      '--keystore=server.p12',
+      '--cacert=root.crt',
+      '--allow-ou=client',
       '--status=unix:{0}'.format(path)])
 
     # wait for startup

--- a/tests/test-server-status-port.py
+++ b/tests/test-server-status-port.py
@@ -17,9 +17,11 @@ if __name__ == "__main__":
 
     # start ghostunnel
     # hack: point target to STATUS_PORT so that /_status doesn't 503.
-    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
-      '--target={0}:{1}'.format(LOCALHOST, STATUS_PORT), '--keystore=server.p12',
-      '--cacert=root.crt', '--allow-ou=client',
+    ghostunnel = run_ghostunnel(['server',
+      '--proxy={0}:13001:{0}:{1}'.format(LOCALHOST, STATUS_PORT),
+      '--keystore=server.p12',
+      '--cacert=root.crt',
+      '--allow-ou=client',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
     urlopen = lambda path: urllib.request.urlopen(path, cafile='root.crt')

--- a/tests/test-server-tls-handshake-timeout.py
+++ b/tests/test-server-tls-handshake-timeout.py
@@ -16,9 +16,12 @@ if __name__ == "__main__":
     root.create_signed_cert('client')
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['server', '--listen={0}:13000'.format(LOCALHOST),
-      '--target={0}:13001'.format(LOCALHOST), '--keystore=server.p12',
-      '--cacert=root.crt', '--allow-ou=client', '--timeout=1s',
+    ghostunnel = run_ghostunnel(['server',
+      '--proxy={0}:13000:{0}:13001'.format(LOCALHOST),
+      '--keystore=server.p12',
+      '--cacert=root.crt',
+      '--allow-ou=client',
+      '--timeout=1s',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
     # connect but don't perform handshake

--- a/tests/test-server-unix-socket-backend.py
+++ b/tests/test-server-unix-socket-backend.py
@@ -16,9 +16,12 @@ if __name__ == "__main__":
 
     # start ghostunnel
     socket = UnixServer()
-    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
-      '--target=unix:{0}'.format(socket.get_socket_path()), '--keystore=server.p12',
-      '--cacert=root.crt', '--allow-ou=client', '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
+    ghostunnel = run_ghostunnel(['server',
+      '--proxy={0}:13001:unix:{1}'.format(LOCALHOST, socket.get_socket_path()),
+      '--keystore=server.p12',
+      '--cacert=root.crt',
+      '--allow-ou=client',
+      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
     # connect with client, confirm that the tunnel is up
     pair = SocketPair(TlsClient('client', 'root', 13001), socket)


### PR DESCRIPTION
Converts everything that was using `--listen` and `--target` to `--proxy.` This should make it easier to implement multi-connect, by passing `--proxy` multiple times a user can specify multiple things to tunnel.