### PR TITLE
1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,7 @@ Start a backend server:
 Start a ghostunnel in server mode to proxy connections:
 
     ghostunnel server \
-        --listen localhost:8443 \
-        --target localhost:8080 \
+        --proxy localhost:8443:localhost:8080 \
         --keystore test-keys/server.p12 \
         --cacert test-keys/root.crt \
         --allow-cn client
@@ -152,8 +151,7 @@ Start a backend TLS server:
 Start a ghostunnel with a client certificate to forward connections:
 
     ghostunnel client \
-        --listen localhost:8080 \
-        --target localhost:8443 \
+        --proxy localhost:8080:localhost:8443 \
         --keystore test-keys/client.p12 \
         --cacert test-keys/root.crt
 
@@ -176,8 +174,7 @@ Start netcat on port `8001`:
 Start the ghostunnel server:
 
     ghostunnel server \
-        --listen localhost:8002 \
-        --target localhost:8001 \
+        --proxy localhost:8002:localhost:8001 \
         --keystore test-keys/server.p12 \
         --cacert test-keys/root.crt \
         --allow-cn client
@@ -185,8 +182,7 @@ Start the ghostunnel server:
 Start the ghostunnel client:
 
     ghostunnel client \
-        --listen localhost:8003 \
-        --target localhost:8002 \
+        --proxy localhost:8003:localhost:8002 \
         --keystore test-keys/client.p12 \
         --cacert test-keys/root.crt
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ Start a backend server:
 Start a ghostunnel in server mode to proxy connections:
 
     ghostunnel server \
-        --proxy localhost:8443:localhost:8080 \
+        --listen localhost:8443 \
+        --target localhost:8080 \
         --keystore test-keys/server.p12 \
         --cacert test-keys/root.crt \
         --allow-cn client
@@ -151,7 +152,8 @@ Start a backend TLS server:
 Start a ghostunnel with a client certificate to forward connections:
 
     ghostunnel client \
-        --proxy localhost:8080:localhost:8443 \
+        --listen localhost:8080 \
+        --target localhost:8443 \
         --keystore test-keys/client.p12 \
         --cacert test-keys/root.crt
 
@@ -174,7 +176,8 @@ Start netcat on port `8001`:
 Start the ghostunnel server:
 
     ghostunnel server \
-        --proxy localhost:8002:localhost:8001 \
+        --listen localhost:8002 \
+        --target localhost:8001 \
         --keystore test-keys/server.p12 \
         --cacert test-keys/root.crt \
         --allow-cn client
@@ -182,7 +185,8 @@ Start the ghostunnel server:
 Start the ghostunnel client:
 
     ghostunnel client \
-        --proxy localhost:8003:localhost:8002 \
+        --listen localhost:8003 \
+        --target localhost:8002 \
         --keystore test-keys/client.p12 \
         --cacert test-keys/root.crt
 

--- a/main.go
+++ b/main.go
@@ -48,20 +48,23 @@ var (
 var (
 	app = kingpin.New("ghostunnel", "A simple SSL/TLS proxy with mutual authentication for securing non-TLS services.")
 
-	serverCommand      = app.Command("server", "Server mode (TLS listener -> plain TCP/UNIX target).")
-	serverProxyStanza  = serverCommand.Flag("proxy", "Proxy stanza (SOURCE:TARGET, e.g. localhost:443:localhost:80).").PlaceHolder("STANZA").Required().String()
-	serverUnsafeTarget = serverCommand.Flag("unsafe-target", "If set, does not limit target to localhost, 127.0.0.1, [::1], or UNIX sockets.").Bool()
-	serverAllowAll     = serverCommand.Flag("allow-all", "Allow all clients, do not check client cert subject.").Bool()
-	serverAllowedCNs   = serverCommand.Flag("allow-cn", "Allow clients with given common name (can be repeated).").PlaceHolder("CN").Strings()
-	serverAllowedOUs   = serverCommand.Flag("allow-ou", "Allow clients with given organizational unit name (can be repeated).").PlaceHolder("OU").Strings()
-	serverAllowedDNSs  = serverCommand.Flag("allow-dns-san", "Allow clients with given DNS subject alternative name (can be repeated).").PlaceHolder("SAN").Strings()
-	serverAllowedIPs   = serverCommand.Flag("allow-ip-san", "Allow clients with given IP subject alternative name (can be repeated).").PlaceHolder("SAN").IPList()
+	serverCommand        = app.Command("server", "Server mode (TLS listener -> plain TCP/UNIX target).")
+	serverListenAddress  = serverCommand.Flag("listen", "Address and port to listen on (HOST:PORT).").PlaceHolder("ADDR").Required().TCP()
+	serverForwardAddress = serverCommand.Flag("target", "Address to forward connections to (HOST:PORT, or unix:PATH).").PlaceHolder("ADDR").Required().String()
+	serverUnsafeTarget   = serverCommand.Flag("unsafe-target", "If set, does not limit target to localhost, 127.0.0.1, [::1], or UNIX sockets.").Bool()
+	serverAllowAll       = serverCommand.Flag("allow-all", "Allow all clients, do not check client cert subject.").Bool()
+	serverAllowedCNs     = serverCommand.Flag("allow-cn", "Allow clients with given common name (can be repeated).").PlaceHolder("CN").Strings()
+	serverAllowedOUs     = serverCommand.Flag("allow-ou", "Allow clients with given organizational unit name (can be repeated).").PlaceHolder("OU").Strings()
+	serverAllowedDNSs    = serverCommand.Flag("allow-dns-san", "Allow clients with given DNS subject alternative name (can be repeated).").PlaceHolder("SAN").Strings()
+	serverAllowedIPs     = serverCommand.Flag("allow-ip-san", "Allow clients with given IP subject alternative name (can be repeated).").PlaceHolder("SAN").IPList()
 
-	clientCommand      = app.Command("client", "Client mode (plain TCP/UNIX listener -> TLS target).")
-	clientProxyStanza  = clientCommand.Flag("proxy", "Proxy stanza (SOURCE:TARGET, e.g. localhost:443:localhost:80).").PlaceHolder("STANZA").Required().String()
-	clientUnsafeListen = clientCommand.Flag("unsafe-listen", "If set, does not limit listen to localhost, 127.0.0.1, [::1], or UNIX sockets.").Bool()
-	clientServerName   = clientCommand.Flag("override-server-name", "If set, overrides the server name used for hostname verification.").PlaceHolder("NAME").String()
-	clientConnectProxy = clientCommand.Flag("connect-proxy", "If set, connect to target over given HTTP CONNECT proxy. Must be HTTP/HTTPS URL.").PlaceHolder("URL").URL()
+	clientCommand       = app.Command("client", "Client mode (plain TCP/UNIX listener -> TLS target).")
+	clientListenAddress = clientCommand.Flag("listen", "Address and port to listen on (HOST:PORT, or unix:PATH).").PlaceHolder("ADDR").Required().String()
+	// Note: can't use .TCP() for clientForwardAddress because we need to set the original string in tls.Config.ServerName.
+	clientForwardAddress = clientCommand.Flag("target", "Address to forward connections to (HOST:PORT).").PlaceHolder("ADDR").Required().String()
+	clientUnsafeListen   = clientCommand.Flag("unsafe-listen", "If set, does not limit listen to localhost, 127.0.0.1, [::1], or UNIX sockets.").Bool()
+	clientServerName     = clientCommand.Flag("override-server-name", "If set, overrides the server name used for hostname verification.").PlaceHolder("NAME").String()
+	clientConnectProxy   = clientCommand.Flag("connect-proxy", "If set, connect to target over given HTTP CONNECT proxy. Must be HTTP/HTTPS URL.").PlaceHolder("URL").URL()
 
 	// TLS options
 	keystorePath        = app.Flag("keystore", "Path to certificate and keystore (PEM, PKCS12).").PlaceHolder("PATH").Required().String()
@@ -136,8 +139,20 @@ func validateFlags(app *kingpin.Application) error {
 }
 
 // Validates that addr is either a unix socket or localhost
-func validateUnixOrLocalhost(addr addressData) bool {
-	return addr.network == "unix" || addr.host == "localhost" || strings.HasPrefix(addr.address, "127.0.0.1:") || strings.HasPrefix(addr.address, "[::1]:")
+func validateUnixOrLocalhost(addr string) bool {
+	if strings.HasPrefix(addr, "unix:") {
+		return true
+	}
+	if strings.HasPrefix(addr, "127.0.0.1:") {
+		return true
+	}
+	if strings.HasPrefix(addr, "[::1]:") {
+		return true
+	}
+	if strings.HasPrefix(addr, "localhost:") {
+		return true
+	}
+	return false
 }
 
 // Validate flags for server mode
@@ -148,13 +163,8 @@ func serverValidateFlags() error {
 	if *serverAllowAll && (len(*serverAllowedCNs) > 0 || len(*serverAllowedOUs) > 0 || len(*serverAllowedDNSs) > 0 || len(*serverAllowedIPs) > 0) {
 		return fmt.Errorf("--allow-all and other access control flags are mutually exclusive")
 	}
-
-	_, target, err := parseProxyStanza(*serverProxyStanza)
-	if err != nil {
-		return err
-	}
-	if !*serverUnsafeTarget && !validateUnixOrLocalhost(target) {
-		return fmt.Errorf("proxy target must be unix:PATH, localhost:PORT, 127.0.0.1:PORT or [::1]:PORT (unless --unsafe-target is set)")
+	if !*serverUnsafeTarget && !validateUnixOrLocalhost(*serverForwardAddress) {
+		return fmt.Errorf("--target must be unix:PATH, localhost:PORT, 127.0.0.1:PORT or [::1]:PORT (unless --unsafe-target is set)")
 	}
 
 	for _, suite := range strings.Split(*enabledCipherSuites, ",") {
@@ -168,12 +178,8 @@ func serverValidateFlags() error {
 
 // Validate flags for client mode
 func clientValidateFlags() error {
-	source, _, err := parseProxyStanza(*clientProxyStanza)
-	if err != nil {
-		return err
-	}
-	if !*clientUnsafeListen && !validateUnixOrLocalhost(source) {
-		return fmt.Errorf("proxy source must be unix:PATH, localhost:PORT, 127.0.0.1:PORT or [::1]:PORT (unless --unsafe-listen is set)")
+	if !*clientUnsafeListen && !validateUnixOrLocalhost(*clientListenAddress) {
+		return fmt.Errorf("--listen must be unix:PATH, localhost:PORT, 127.0.0.1:PORT or [::1]:PORT (unless --unsafe-listen is set)")
 	}
 
 	for _, suite := range strings.Split(*enabledCipherSuites, ",") {
@@ -247,13 +253,7 @@ func run(args []string) error {
 		}
 		logger.Printf("starting ghostunnel in server mode")
 
-		source, target, err := parseProxyStanza(*serverProxyStanza)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "error: invalid proxy stanza: %s\n", err)
-			return err
-		}
-
-		dial, err := serverBackendDialer(target)
+		dial, err := serverBackendDialer()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error: invalid target address: %s\n", err)
 			return err
@@ -263,7 +263,7 @@ func run(args []string) error {
 		context := &Context{watcher, status, nil, dial, metrics, cert}
 
 		// Start listening
-		err = serverListen(context, source)
+		err = serverListen(context)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error from server listen: %s\n", err)
 		}
@@ -276,13 +276,13 @@ func run(args []string) error {
 		}
 		logger.Printf("starting ghostunnel in client mode")
 
-		source, target, err := parseProxyStanza(*clientProxyStanza)
+		network, address, host, err := parseUnixOrTCPAddress(*clientForwardAddress)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "error: invalid proxy stanza: %s\n", err)
+			fmt.Fprintf(os.Stderr, "error: invalid target address: %s\n", err)
 			return err
 		}
 
-		dial, err := clientBackendDialer(cert, target)
+		dial, err := clientBackendDialer(cert, network, address, host)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error: unable to build dialer: %s\n", err)
 			return err
@@ -292,7 +292,7 @@ func run(args []string) error {
 		context := &Context{watcher, status, nil, dial, metrics, cert}
 
 		// Start listening
-		err = clientListen(context, source)
+		err = clientListen(context)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error from client listen: %s\n", err)
 		}
@@ -307,21 +307,17 @@ func run(args []string) error {
 // allows us to have multiple sockets listening on the same port and accept
 // connections. This is useful for the purpose of replacing certificates
 // in-place without having to take downtime, e.g. if a certificate is expiring.
-func serverListen(context *Context, addr addressData) error {
+func serverListen(context *Context) error {
 	config, err := buildConfig(*caBundlePath)
 	if err != nil {
 		logger.Printf("error trying to read CA bundle: %s", err)
 		return err
 	}
 
-	if addr.network == "unix" {
-		return fmt.Errorf("address type %s not supported in server listen", addr.network)
-	}
-
 	config.GetCertificate = context.cert.getCertificate
 	config.VerifyPeerCertificate = verifyPeerCertificate
 
-	listener, err := reuseport.NewReusablePortListener(addr.network, addr.address)
+	listener, err := reuseport.NewReusablePortListener("tcp", (*serverListenAddress).String())
 	if err != nil {
 		logger.Printf("error trying to listen: %s", err)
 		return err
@@ -355,8 +351,15 @@ func serverListen(context *Context, addr addressData) error {
 }
 
 // Open listening socket in client mode.
-func clientListen(context *Context, addr addressData) error {
-	listener, err := net.Listen(addr.network, addr.address)
+func clientListen(context *Context) error {
+	// Setup listening socket
+	network, address, _, err := parseUnixOrTCPAddress(*clientListenAddress)
+	if err != nil {
+		logger.Printf("error parsing client listen address: %s", err)
+		return err
+	}
+
+	listener, err := net.Listen(network, address)
 	if err != nil {
 		logger.Printf("error opening socket: %s", err)
 		return err
@@ -411,17 +414,17 @@ func (context *Context) serveStatus() error {
 	config.ClientAuth = tls.NoClientCert
 	config.GetCertificate = context.cert.getCertificate
 
-	addr, err := parseUnixOrTCPAddress(*statusAddress)
+	network, address, _, err := parseUnixOrTCPAddress(*statusAddress)
 	if err != nil {
 		return err
 	}
 
 	var listener net.Listener
-	if addr.network == "unix" {
-		listener, err = net.Listen(addr.network, addr.address)
+	if network == "unix" {
+		listener, err = net.Listen(network, address)
 		listener.(*net.UnixListener).SetUnlinkOnClose(true)
 	} else {
-		listener, err = reuseport.NewReusablePortListener(addr.network, addr.address)
+		listener, err = reuseport.NewReusablePortListener(network, address)
 	}
 
 	if err != nil {
@@ -429,7 +432,7 @@ func (context *Context) serveStatus() error {
 		return err
 	}
 
-	if addr.network != "unix" {
+	if network != "unix" {
 		listener = tls.NewListener(listener, config)
 	}
 
@@ -444,21 +447,26 @@ func (context *Context) serveStatus() error {
 }
 
 // Get backend dialer function in server mode (connecting to a unix socket or tcp port)
-func serverBackendDialer(addr addressData) (func() (net.Conn, error), error) {
+func serverBackendDialer() (func() (net.Conn, error), error) {
+	backendNet, backendAddr, _, err := parseUnixOrTCPAddress(*serverForwardAddress)
+	if err != nil {
+		return nil, err
+	}
+
 	return func() (net.Conn, error) {
-		return net.DialTimeout(addr.network, addr.address, *timeoutDuration)
+		return net.DialTimeout(backendNet, backendAddr, *timeoutDuration)
 	}, nil
 }
 
 // Get backend dialer function in client mode (connecting to a TLS port)
-func clientBackendDialer(cert *certificate, addr addressData) (func() (net.Conn, error), error) {
+func clientBackendDialer(cert *certificate, network, address, host string) (func() (net.Conn, error), error) {
 	config, err := buildConfig(*caBundlePath)
 	if err != nil {
 		return nil, err
 	}
 
 	if *clientServerName == "" {
-		config.ServerName = addr.host
+		config.ServerName = host
 	} else {
 		config.ServerName = *clientServerName
 	}
@@ -484,6 +492,6 @@ func clientBackendDialer(cert *certificate, addr addressData) (func() (net.Conn,
 		// Fetch latest cached certificate before initiating new connection
 		crt, _ := cert.getCertificate(nil)
 		config.Certificates = []tls.Certificate{*crt}
-		return dialWithDialer(dialer, *timeoutDuration, addr.network, addr.address, config)
+		return dialWithDialer(dialer, *timeoutDuration, network, address, config)
 	}, nil
 }

--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ var (
 	enabledCipherSuites = app.Flag("cipher-suites", "Set of cipher suites to enable, in order of preference (AES, CHACHA).").Default("AES", "CHACHA").Enums("AES", "CHACHA")
 	timedReload         = app.Flag("timed-reload", "Reload keystores every given interval (e.g. 300s), refresh listener/client on changes.").PlaceHolder("DURATION").Duration()
 	shutdownTimeout     = app.Flag("shutdown-timeout", "Graceful shutdown timeout. Terminates after timeout even if connections still open.").Default("5m").Duration()
-	timeoutDuration     = app.Flag("timeout", "Timeout for establishing connections, handshakes.").Default("10s").Duration()
+	timeoutDuration     = app.Flag("connect-timeout", "Timeout for establishing connections, handshakes.").Default("10s").Duration()
 	graphiteAddr        = app.Flag("graphite", "Collect metrics and report them to the given graphite instance (raw TCP).").PlaceHolder("ADDR").TCP()
 	metricsURL          = app.Flag("metrics-url", "Collect metrics and POST them periodically to the given URL (via HTTP/JSON).").PlaceHolder("URL").String()
 	metricsPrefix       = app.Flag("metrics-prefix", fmt.Sprintf("Set prefix string for all reported metrics (default: %s).", defaultMetricsPrefix)).PlaceHolder("PREFIX").Default(defaultMetricsPrefix).String()

--- a/main.go
+++ b/main.go
@@ -63,20 +63,27 @@ var (
 	clientServerName   = clientCommand.Flag("override-server-name", "If set, overrides the server name used for hostname verification.").PlaceHolder("NAME").String()
 	clientConnectProxy = clientCommand.Flag("connect-proxy", "If set, connect to target over given HTTP CONNECT proxy. Must be HTTP/HTTPS URL.").PlaceHolder("URL").URL()
 
+	// TLS options
 	keystorePath        = app.Flag("keystore", "Path to certificate and keystore (PEM, PKCS12).").PlaceHolder("PATH").Required().String()
 	keystorePass        = app.Flag("storepass", "Password for certificate and keystore (optional).").PlaceHolder("PASS").String()
 	caBundlePath        = app.Flag("cacert", "Path to CA bundle file (PEM/X509). Uses system trust store by default.").String()
 	enabledCipherSuites = app.Flag("cipher-suites", "Set of cipher suites to enable, in order of preference (AES, CHACHA).").Default("AES", "CHACHA").Enums("AES", "CHACHA")
-	timedReload         = app.Flag("timed-reload", "Reload keystores every given interval (e.g. 300s), refresh listener/client on changes.").PlaceHolder("DURATION").Duration()
-	shutdownTimeout     = app.Flag("shutdown-timeout", "Graceful shutdown timeout. Terminates after timeout even if connections still open.").Default("5m").Duration()
-	timeoutDuration     = app.Flag("connect-timeout", "Timeout for establishing connections, handshakes.").Default("10s").Duration()
-	graphiteAddr        = app.Flag("graphite", "Collect metrics and report them to the given graphite instance (raw TCP).").PlaceHolder("ADDR").TCP()
-	metricsURL          = app.Flag("metrics-url", "Collect metrics and POST them periodically to the given URL (via HTTP/JSON).").PlaceHolder("URL").String()
-	metricsPrefix       = app.Flag("metrics-prefix", fmt.Sprintf("Set prefix string for all reported metrics (default: %s).", defaultMetricsPrefix)).PlaceHolder("PREFIX").Default(defaultMetricsPrefix).String()
-	metricsInterval     = app.Flag("metrics-interval", "Collect (and post) metrics every specified interval.").Default("30s").Duration()
-	statusAddress       = app.Flag("status", "Enable serving /_status and /_metrics on given HOST:PORT (or unix:SOCKET).").PlaceHolder("ADDR").String()
-	enableProf          = app.Flag("enable-pprof", "Enable serving /debug/pprof endpoints alongside /_status (for profiling).").Bool()
-	useSyslog           = app.Flag("syslog", "Send logs to syslog instead of stderr.").Bool()
+
+	// Reloading and timeouts
+	timedReload     = app.Flag("timed-reload", "Reload keystores every given interval (e.g. 300s), refresh listener/client on changes.").PlaceHolder("DURATION").Duration()
+	shutdownTimeout = app.Flag("shutdown-timeout", "Graceful shutdown timeout. Terminates after timeout even if connections still open.").Default("5m").Duration()
+	timeoutDuration = app.Flag("connect-timeout", "Timeout for establishing connections, handshakes.").Default("10s").Duration()
+
+	// Metrics options
+	metricsGraphite = app.Flag("metrics-graphite", "Collect metrics and report them to the given graphite instance (raw TCP).").PlaceHolder("ADDR").TCP()
+	metricsURL      = app.Flag("metrics-url", "Collect metrics and POST them periodically to the given URL (via HTTP/JSON).").PlaceHolder("URL").String()
+	metricsPrefix   = app.Flag("metrics-prefix", fmt.Sprintf("Set prefix string for all reported metrics (default: %s).", defaultMetricsPrefix)).PlaceHolder("PREFIX").Default(defaultMetricsPrefix).String()
+	metricsInterval = app.Flag("metrics-interval", "Collect (and post) metrics every specified interval.").Default("30s").Duration()
+
+	// Status & logging
+	statusAddress = app.Flag("status", "Enable serving /_status and /_metrics on given HOST:PORT (or unix:SOCKET).").PlaceHolder("ADDR").String()
+	enableProf    = app.Flag("enable-pprof", "Enable serving /debug/pprof endpoints alongside /_status (for profiling).").Bool()
+	useSyslog     = app.Flag("syslog", "Send logs to syslog instead of stderr.").Bool()
 )
 
 var exitFunc = os.Exit

--- a/main_test.go
+++ b/main_test.go
@@ -137,36 +137,50 @@ func TestServerFlagValidation(t *testing.T) {
 	*serverAllowedIPs = []net.IP{net.IPv4(0, 0, 0, 0)}
 	err = serverValidateFlags()
 	assert.NotNil(t, err, "--allow-all and --allow-ip-san are mutually exclusive")
+
+	*serverAllowAll = false
+	*serverUnsafeTarget = false
+	*serverForwardAddress = "foo.com"
+	err = serverValidateFlags()
+	assert.NotNil(t, err, "unsafe target should be rejected")
 }
 
 func TestClientFlagValidation(t *testing.T) {
 	*clientUnsafeListen = false
-	*clientProxyStanza = "0.0.0.0:8080:localhost:8080"
+	*clientListenAddress = "0.0.0.0:8080"
 	err := clientValidateFlags()
 	assert.NotNil(t, err, "unsafe listen should be rejected")
 }
 
 func TestAllowsLocalhost(t *testing.T) {
 	*serverUnsafeTarget = false
-	assert.True(t, validateUnixOrLocalhost(addressData{"tcp", "localhost:80", "localhost"}), "localhost should be allowed")
-	assert.True(t, validateUnixOrLocalhost(addressData{"tcp", "127.0.0.1:80", "127.0.0.1"}), "127.0.0.1 should be allowed")
-	assert.True(t, validateUnixOrLocalhost(addressData{"tcp", "[::1]:80", "[::1]"}), "[::1] should be allowed")
-	assert.True(t, validateUnixOrLocalhost(addressData{"unix", "/tmp/foo", ""}), "unix:/tmp/foo should be allowed")
+	assert.True(t, validateUnixOrLocalhost("localhost:1234"), "localhost should be allowed")
+	assert.True(t, validateUnixOrLocalhost("127.0.0.1:1234"), "127.0.0.1 should be allowed")
+	assert.True(t, validateUnixOrLocalhost("[::1]:1234"), "[::1] should be allowed")
+	assert.True(t, validateUnixOrLocalhost("unix:/tmp/foo"), "unix:/tmp/foo should be allowed")
 }
 
 func TestDisallowsFooDotCom(t *testing.T) {
 	*serverUnsafeTarget = false
-	assert.False(t, validateUnixOrLocalhost(addressData{"tcp", "foo.com:80", "foo.com"}), "foo.com should be disallowed")
-	assert.False(t, validateUnixOrLocalhost(addressData{"tcp", "localhost.com:80", "localhost.com"}), "localhost.com should be disallowed")
-	assert.False(t, validateUnixOrLocalhost(addressData{"tcp", "74.122.190.83:1234", "74.122.190.83"}), "random ip address should be disallowed")
+	assert.False(t, validateUnixOrLocalhost("foo.com:1234"), "foo.com should be disallowed")
+	assert.False(t, validateUnixOrLocalhost("alocalhost.com:1234"), "alocalhost.com should be disallowed")
+	assert.False(t, validateUnixOrLocalhost("localhost.com.foo.com:1234"), "localhost.com.foo.com should be disallowed")
+	assert.False(t, validateUnixOrLocalhost("74.122.190.83:1234"), "random ip address should be disallowed")
+}
+
+func TestServerBackendDialerError(t *testing.T) {
+	*serverForwardAddress = "invalid"
+	_, err := serverBackendDialer()
+	assert.NotNil(t, err, "invalid forward address should not have dialer")
 }
 
 func TestInvalidCABundle(t *testing.T) {
 	err := run([]string{
 		"server",
 		"--cacert", "/dev/null",
+		"--target", "localhost:8080",
 		"--keystore", "keystore.p12",
-		"--proxy", "localhost:8080:localhost:8080",
+		"--listen", "localhost:8080",
 	})
 	assert.NotNil(t, err, "invalid CA bundle should exit with error")
 }

--- a/net.go
+++ b/net.go
@@ -149,12 +149,12 @@ func parseUnixOrTCPAddress(input string) (network, address, host string, err err
 		return
 	}
 
-	var tcp *net.TCPAddr
-	tcp, err = net.ResolveTCPAddr("tcp", input)
+	// Make sure target address resolves
+	_, err = net.ResolveTCPAddr("tcp", input)
 	if err != nil {
 		return
 	}
 
-	network, address = "tcp", tcp.String()
+	network, address = "tcp", input
 	return
 }

--- a/net.go
+++ b/net.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"crypto/tls"
-	"fmt"
 	"io"
 	"net"
 	"strings"
@@ -34,10 +33,6 @@ type proxy struct {
 	listener net.Listener
 	handlers *sync.WaitGroup
 	dial     func() (net.Conn, error)
-}
-
-type addressData struct {
-	network, address, host string
 }
 
 var (
@@ -139,41 +134,17 @@ func copyData(dst net.Conn, src net.Conn) {
 	}
 }
 
-// Parse a proxy stanza string of the form SOURCE:TARGET, where both SOURCE and/or
-// target can be HOST:PORT (TCP) or unix:PATH (UNIX domain socket).
-func parseProxyStanza(input string) (source, target addressData, err error) {
-	components := strings.Split(input, ":")
-	if len(components) != 4 {
-		err = fmt.Errorf("invalid proxy stanza: %s", input)
-		return
-	}
-
-	sourceRaw := fmt.Sprintf("%s:%s", components[0], components[1])
-	source, err = parseUnixOrTCPAddress(sourceRaw)
-	if err != nil {
-		return
-	}
-
-	targetRaw := fmt.Sprintf("%s:%s", components[2], components[3])
-	target, err = parseUnixOrTCPAddress(targetRaw)
-	if err != nil {
-		return
-	}
-
-	return
-}
-
 // Parse a string representing a TCP address or UNIX socket for our backend
 // target. The input can be or the form "HOST:PORT" for TCP or "unix:PATH"
 // for a UNIX socket.
-func parseUnixOrTCPAddress(input string) (addr addressData, err error) {
+func parseUnixOrTCPAddress(input string) (network, address, host string, err error) {
 	if strings.HasPrefix(input, "unix:") {
-		addr.network = "unix"
-		addr.address = input[5:]
+		network = "unix"
+		address = input[5:]
 		return
 	}
 
-	addr.host, _, err = net.SplitHostPort(input)
+	host, _, err = net.SplitHostPort(input)
 	if err != nil {
 		return
 	}
@@ -184,6 +155,6 @@ func parseUnixOrTCPAddress(input string) (addr addressData, err error) {
 		return
 	}
 
-	addr.network, addr.address = "tcp", tcp.String()
+	network, address = "tcp", tcp.String()
 	return
 }

--- a/net_test.go
+++ b/net_test.go
@@ -35,11 +35,10 @@ func TestParseUnixOrTcpAddress(t *testing.T) {
 	}
 
 	network, address, host, _ = parseUnixOrTCPAddress("localhost:8080")
-	// note: ipv6 test is probably fragile, we don't expand ::1.
 	if network != "tcp" {
 		t.Errorf("unexpected network: %s", network)
 	}
-	if address != "127.0.0.1:8080" && address != "[::1]:8080" {
+	if address != "localhost:8080" {
 		t.Errorf("unexpected address: %s", address)
 	}
 	if host != "localhost" {

--- a/net_test.go
+++ b/net_test.go
@@ -23,32 +23,32 @@ import (
 )
 
 func TestParseUnixOrTcpAddress(t *testing.T) {
-	addr, _ := parseUnixOrTCPAddress("unix:/tmp/foo")
-	if addr.network != "unix" {
-		t.Errorf("unexpected network: %s", addr.network)
+	network, address, host, _ := parseUnixOrTCPAddress("unix:/tmp/foo")
+	if network != "unix" {
+		t.Errorf("unexpected network: %s", network)
 	}
-	if addr.address != "/tmp/foo" {
-		t.Errorf("unexpected address: %s", addr.address)
+	if address != "/tmp/foo" {
+		t.Errorf("unexpected address: %s", address)
 	}
-	if addr.host != "" {
-		t.Errorf("unexpected host: %s", addr.host)
+	if host != "" {
+		t.Errorf("unexpected host: %s", host)
 	}
 
-	addr, _ = parseUnixOrTCPAddress("localhost:8080")
+	network, address, host, _ = parseUnixOrTCPAddress("localhost:8080")
 	// note: ipv6 test is probably fragile, we don't expand ::1.
-	if addr.network != "tcp" {
-		t.Errorf("unexpected network: %s", addr.network)
+	if network != "tcp" {
+		t.Errorf("unexpected network: %s", network)
 	}
-	if addr.address != "127.0.0.1:8080" && addr.address != "[::1]:8080" {
-		t.Errorf("unexpected address: %s", addr.address)
+	if address != "127.0.0.1:8080" && address != "[::1]:8080" {
+		t.Errorf("unexpected address: %s", address)
 	}
-	if addr.host != "localhost" {
-		t.Errorf("unexpected host: %s", addr.host)
+	if host != "localhost" {
+		t.Errorf("unexpected host: %s", host)
 	}
 
-	_, err := parseUnixOrTCPAddress("localhost")
+	_, _, _, err := parseUnixOrTCPAddress("localhost")
 	assert.NotNil(t, err, "was able to parse invalid host/port")
 
-	_, err = parseUnixOrTCPAddress("256.256.256.256:99999")
+	_, _, _, err = parseUnixOrTCPAddress("256.256.256.256:99999")
 	assert.NotNil(t, err, "was able to parse invalid host/port")
 }

--- a/tests/test-client-auto-reload-certificate.py
+++ b/tests/test-client-auto-reload-certificate.py
@@ -24,11 +24,9 @@ if __name__ == "__main__":
     root2.create_signed_cert('server2')
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['client',
-      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
-      '--keystore=client1.p12',
-      '--timed-reload=1s',
-      '--cacert=root1.crt',
+    ghostunnel = run_ghostunnel(['client', '--listen={0}:13001'.format(LOCALHOST),
+      '--target={0}:13002'.format(LOCALHOST), '--keystore=client1.p12',
+      '--timed-reload=1s', '--cacert=root1.crt',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
     # ensure ghostunnel connects with server1

--- a/tests/test-client-concurrent-connections.py
+++ b/tests/test-client-concurrent-connections.py
@@ -37,11 +37,10 @@ if __name__ == "__main__":
       root.create_signed_cert("server{0}".format(i))
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['client',
-      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
-      '--keystore=client.p12',
-      '--cacert=root.crt',
-      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
+    ghostunnel = run_ghostunnel(['client', '--listen={0}:13001'.format(LOCALHOST),
+      '--target={0}:13002'.format(LOCALHOST), '--keystore=client.p12',
+      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
+      '--cacert=root.crt'])
 
     # servers should be able to communicate all at the same time.
     proc = []

--- a/tests/test-client-handles-client-closes-connection.py
+++ b/tests/test-client-handles-client-closes-connection.py
@@ -16,11 +16,10 @@ if __name__ == "__main__":
     root.create_signed_cert('client')
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['client',
-      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
-      '--keystore=client.p12',
-      '--cacert=root.crt',
-      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
+    ghostunnel = run_ghostunnel(['client', '--listen={0}:13001'.format(LOCALHOST),
+      '--target={0}:13002'.format(LOCALHOST), '--keystore=client.p12',
+      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
+      '--cacert=root.crt'])
 
     # connect to server, confirm that the tunnel is up
     pair = SocketPair(TcpClient(13001), TlsServer('server', 'root', 13002))

--- a/tests/test-client-handles-no-server.py
+++ b/tests/test-client-handles-no-server.py
@@ -16,11 +16,9 @@ if __name__ == "__main__":
     root.create_signed_cert('client')
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['client',
-      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
-      '--keystore=client.p12',
-      '--cacert=root.crt',
-      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
+    ghostunnel = run_ghostunnel(['client', '--listen={0}:13001'.format(LOCALHOST),
+      '--target={0}:13002'.format(LOCALHOST), '--keystore=client.p12',
+      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT), '--cacert=root.crt'])
 
     # client should fail to connect since nothing is listening on 13003
     try:

--- a/tests/test-client-handles-server-closes-connection.py
+++ b/tests/test-client-handles-server-closes-connection.py
@@ -16,11 +16,9 @@ if __name__ == "__main__":
     root.create_signed_cert('client')
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['client',
-      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
-      '--keystore=client.p12',
-      '--cacert=root.crt',
-      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
+    ghostunnel = run_ghostunnel(['client', '--listen={0}:13001'.format(LOCALHOST),
+      '--target={0}:13002'.format(LOCALHOST), '--keystore=client.p12',
+      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT), '--cacert=root.crt'])
 
     # connect with client, confirm that the tunnel is up
     pair = SocketPair(TcpClient(13001), TlsServer('server', 'root', 13002))

--- a/tests/test-client-metrics-bridge.py
+++ b/tests/test-client-metrics-bridge.py
@@ -27,11 +27,9 @@ if __name__ == "__main__":
     server.start()
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['client',
-      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
-      '--keystore=client.p12',
-      '--cacert=root.crt',
-      '--metrics-interval=1s',
+    ghostunnel = run_ghostunnel(['client', '--listen={0}:13001'.format(LOCALHOST),
+      '--target={0}:13002'.format(LOCALHOST), '--keystore=client.p12',
+      '--cacert=root.crt', '--metrics-interval=1s',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
       '--metrics-url=http://localhost:13080/post'])
 

--- a/tests/test-client-metrics-graphite.py
+++ b/tests/test-client-metrics-graphite.py
@@ -27,7 +27,7 @@ if __name__ == "__main__":
       '--cacert=root.crt',
       '--metrics-interval=1s',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
-      '--graphite=localhost:13099'])
+      '--metrics-graphite=localhost:13099'])
 
     # wait for metrics to be sent
     conn, addr = m.accept()

--- a/tests/test-client-metrics-graphite.py
+++ b/tests/test-client-metrics-graphite.py
@@ -21,13 +21,10 @@ if __name__ == "__main__":
     m.listen(1)
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['client',
-      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
-      '--keystore=client.p12',
-      '--cacert=root.crt',
-      '--metrics-interval=1s',
-      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
-      '--metrics-graphite=localhost:13099'])
+    ghostunnel = run_ghostunnel(['client', '--listen={0}:13001'.format(LOCALHOST),
+      '--target={0}:13002'.format(LOCALHOST), '--keystore=client.p12',
+      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT), '--metrics-interval=1s',
+      '--cacert=root.crt', '--metrics-graphite=localhost:13099'])
 
     # wait for metrics to be sent
     conn, addr = m.accept()

--- a/tests/test-client-override-server-name.py
+++ b/tests/test-client-override-server-name.py
@@ -20,12 +20,9 @@ if __name__ == "__main__":
     other_root.create_signed_cert('other_server')
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['client',
-      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
-      '--keystore=client.p12',
-      '--timed-reload=1s',
-      '--cacert=root.crt',
-      '--override-server-name=foobar',
+    ghostunnel = run_ghostunnel(['client', '--listen={0}:13001'.format(LOCALHOST),
+      '--target=localhost:13002', '--keystore=client.p12', '--cacert=root.crt',
+      '--timed-reload=1s', '--override-server-name=foobar',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
     # connect to server1, confirm that the tunnel is up

--- a/tests/test-client-rejects-invalid-san-or-ca.py
+++ b/tests/test-client-rejects-invalid-san-or-ca.py
@@ -14,16 +14,14 @@ if __name__ == "__main__":
     root = RootCert('root')
     root.create_signed_cert('server1')
     root.create_signed_cert('client')
-    root.create_signed_cert('server2', san="DNS:foobar")
+    root.create_signed_cert('server2', san="IP:127.0.0.1,IP:::1,DNS:foobar")
 
     other_root = RootCert('other_root')
     other_root.create_signed_cert('other_server')
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['client',
-      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
-      '--keystore=client.p12',
-      '--cacert=root.crt',
+    ghostunnel = run_ghostunnel(['client', '--listen={0}:13001'.format(LOCALHOST),
+      '--target=localhost:13002', '--keystore=client.p12', '--cacert=root.crt',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
     # connect to server1, confirm that the tunnel is up
@@ -42,9 +40,9 @@ if __name__ == "__main__":
     # connect to server2, confirm that the tunnel isn't up
     try:
       pair = SocketPair(TcpClient(13001), TlsServer('server2', 'root', 13002))
-      raise Exception('failed to reject server2')
+      raise Exception('failed to reject serve2')
     except ssl.SSLError:
-      print_ok("server2 correctly rejected")
+      print_ok("other_server correctly rejected")
 
     print_ok("OK")
   finally:

--- a/tests/test-client-reload-broken-certificate.py
+++ b/tests/test-client-reload-broken-certificate.py
@@ -20,11 +20,9 @@ if __name__ == "__main__":
     root1.create_signed_cert('client1')
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['client',
-      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
-      '--keystore=client1.p12',
-      '--cacert=root1.crt',
-      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
+    ghostunnel = run_ghostunnel(['client', '--listen={0}:13001'.format(LOCALHOST),
+      '--target={0}:13002'.format(LOCALHOST), '--keystore=client1.p12',
+      '--cacert=root1.crt', '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
     # ensure ghostunnel connects with server1
     pair1 = SocketPair(TcpClient(13001), TlsServer('server1', 'root1', 13002))

--- a/tests/test-client-reloads-certificate.py
+++ b/tests/test-client-reloads-certificate.py
@@ -24,11 +24,9 @@ if __name__ == "__main__":
     root2.create_signed_cert('server2')
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['client',
-      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
-      '--keystore=client1.p12',
-      '--cacert=root1.crt',
-      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
+    ghostunnel = run_ghostunnel(['client', '--listen={0}:13001'.format(LOCALHOST),
+      '--target={0}:13002'.format(LOCALHOST), '--keystore=client1.p12',
+      '--cacert=root1.crt', '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
     # ensure ghostunnel connects with server1
     pair1 = SocketPair(TcpClient(13001), TlsServer('server1', 'root1', 13002))

--- a/tests/test-client-shutdown-sigterm.py
+++ b/tests/test-client-shutdown-sigterm.py
@@ -13,11 +13,9 @@ if __name__ == "__main__":
     root.create_signed_cert('client')
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['client',
-      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
-      '--keystore=client.p12',
-      '--cacert=root.crt',
-      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
+    ghostunnel = run_ghostunnel(['client', '--listen={0}:13001'.format(LOCALHOST),
+      '--target={0}:13002'.format(LOCALHOST), '--keystore=client.p12',
+      '--cacert=root.crt', '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
     # wait for startup
     TlsClient(None, 'root', STATUS_PORT).connect(20, 'client')

--- a/tests/test-client-shutdown-timeout.py
+++ b/tests/test-client-shutdown-timeout.py
@@ -13,11 +13,9 @@ if __name__ == "__main__":
     root.create_signed_cert('client')
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['client',
-      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
-      '--keystore=client.p12',
-      '--cacert=root.crt',
-      '--shutdown-timeout=1s',
+    ghostunnel = run_ghostunnel(['client', '--listen={0}:13001'.format(LOCALHOST),
+      '--target={0}:13002'.format(LOCALHOST), '--keystore=client.p12',
+      '--cacert=root.crt', '--shutdown-timeout=1s',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
     # wait for startup

--- a/tests/test-client-status-port.py
+++ b/tests/test-client-status-port.py
@@ -16,11 +16,9 @@ if __name__ == "__main__":
 
     # start ghostunnel
     # hack: point target to STATUS_PORT so that /_status doesn't 503.
-    ghostunnel = run_ghostunnel(['client',
-      '--proxy={0}:13001:{0}:{1}'.format(LOCALHOST, STATUS_PORT),
-      '--keystore=client.p12',
-      '--cacert=root.crt',
-      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
+    ghostunnel = run_ghostunnel(['client', '--listen={0}:13001'.format(LOCALHOST),
+      '--target={0}:{1}'.format(LOCALHOST, STATUS_PORT), '--keystore=client.p12',
+      '--cacert=root.crt', '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
     urlopen = lambda path: urllib.request.urlopen(path, cafile='root.crt')
 

--- a/tests/test-client-unix-socket-backend.py
+++ b/tests/test-client-unix-socket-backend.py
@@ -16,11 +16,9 @@ if __name__ == "__main__":
 
     # start ghostunnel
     socket = UnixClient()
-    ghostunnel = run_ghostunnel(['client',
-      '--proxy=unix:{0}:{1}:13002'.format(socket.get_socket_path(), LOCALHOST),
-      '--keystore=client.p12',
-      '--cacert=root.crt',
-      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
+    ghostunnel = run_ghostunnel(['client', '--listen=unix:{0}'.format(socket.get_socket_path()),
+      '--target={0}:13002'.format(LOCALHOST), '--keystore=client.p12',
+      '--cacert=root.crt', '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
     # connect with client, confirm that the tunnel is up
     pair = SocketPair(socket, TlsServer('server', 'root', 13002))

--- a/tests/test-client-via-http-connect-proxy.py
+++ b/tests/test-client-via-http-connect-proxy.py
@@ -49,12 +49,9 @@ if __name__ == "__main__":
     server.start()
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['client',
-      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
-      '--keystore=client.p12',
-      '--connect-proxy=http://localhost:13080',
-      '--connect-timeout=30s',
-      '--cacert=root.crt',
+    ghostunnel = run_ghostunnel(['client', '--listen={0}:13001'.format(LOCALHOST),
+      '--target=localhost:13002', '--keystore=client.p12', '--cacert=root.crt',
+      '--connect-proxy=http://localhost:13080', '--connect-timeout=30s',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
     # connect to server, confirm that the tunnel is up

--- a/tests/test-client-via-http-connect-proxy.py
+++ b/tests/test-client-via-http-connect-proxy.py
@@ -44,14 +44,14 @@ if __name__ == "__main__":
     root.create_signed_cert('server')
     root.create_signed_cert('client')
 
-    httpd = http.server.HTTPServer(('localhost',13080), FakeConnectProxyHandler)
+    httpd = http.server.HTTPServer((LOCALHOST,13080), FakeConnectProxyHandler)
     server = threading.Thread(target=httpd.handle_request)
     server.start()
 
     # start ghostunnel
     ghostunnel = run_ghostunnel(['client', '--listen={0}:13001'.format(LOCALHOST),
-      '--target=localhost:13002', '--keystore=client.p12', '--cacert=root.crt',
-      '--connect-proxy=http://localhost:13080', '--connect-timeout=30s',
+      '--target={0}:13002'.format(LOCALHOST), '--keystore=client.p12', '--cacert=root.crt',
+      '--connect-proxy=http://{0}:13080'.format(LOCALHOST), '--connect-timeout=30s',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
     # connect to server, confirm that the tunnel is up

--- a/tests/test-client-via-http-connect-proxy.py
+++ b/tests/test-client-via-http-connect-proxy.py
@@ -53,7 +53,7 @@ if __name__ == "__main__":
       '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
       '--keystore=client.p12',
       '--connect-proxy=http://localhost:13080',
-      '--timeout=30s',
+      '--connect-timeout=30s',
       '--cacert=root.crt',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 

--- a/tests/test-server-auto-reload-certificate.py
+++ b/tests/test-server-auto-reload-certificate.py
@@ -16,13 +16,10 @@ if __name__ == "__main__":
     root.create_signed_cert('client')
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['server',
-        '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
-        '--keystore=server.p12',
-        '--cacert=root.crt',
-        '--allow-ou=client',
-        '--timed-reload=1s',
-        '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
+    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
+      '--target={0}:13002'.format(LOCALHOST), '--keystore=server.p12',
+      '--cacert=root.crt', '--allow-ou=client', '--timed-reload=1s',
+      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
     # create connections with client
     pair1 = SocketPair(TlsClient('client', 'root', 13001), TcpServer(13002))

--- a/tests/test-server-concurrent-connections.py
+++ b/tests/test-server-concurrent-connections.py
@@ -39,9 +39,8 @@ if __name__ == "__main__":
       allow_ou.append("--allow-ou=client{0}".format(i))
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['server',
-      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
-      '--keystore=server.p12',
+    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
+      '--target={0}:13002'.format(LOCALHOST), '--keystore=server.p12',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
       '--cacert=root.crt'] + allow_ou)
 

--- a/tests/test-server-handles-client-closes-connection.py
+++ b/tests/test-server-handles-client-closes-connection.py
@@ -16,12 +16,10 @@ if __name__ == "__main__":
     root.create_signed_cert('client')
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['server',
-      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
-      '--keystore=server.p12',
+    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
+      '--target={0}:13002'.format(LOCALHOST), '--keystore=server.p12',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
-      '--cacert=root.crt',
-      '--allow-ou=client'])
+      '--cacert=root.crt', '--allow-ou=client'])
 
     # connect with client, confirm that the tunnel is up
     pair = SocketPair(TlsClient('client', 'root', 13001), TcpServer(13002))

--- a/tests/test-server-handles-no-server.py
+++ b/tests/test-server-handles-no-server.py
@@ -16,12 +16,10 @@ if __name__ == "__main__":
     root.create_signed_cert('client')
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['server',
-      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
-      '--keystore=server.p12',
+    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
+      '--target={0}:13002'.format(LOCALHOST), '--keystore=server.p12',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
-      '--cacert=root.crt',
-      '--allow-ou=client'])
+      '--cacert=root.crt', '--allow-ou=client'])
 
     # client should fail to connect since nothing is listening on 13003
     try:

--- a/tests/test-server-handles-server-closes-connection.py
+++ b/tests/test-server-handles-server-closes-connection.py
@@ -16,12 +16,10 @@ if __name__ == "__main__":
     root.create_signed_cert('client')
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['server',
-      '--proxy={0}:13001:{0}:13000'.format(LOCALHOST),
-      '--keystore=server.p12',
+    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
+      '--target={0}:13000'.format(LOCALHOST), '--keystore=server.p12',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
-      '--cacert=root.crt',
-      '--allow-ou=client'])
+      '--cacert=root.crt', '--allow-ou=client'])
 
     # connect with client, confirm that the tunnel is up
     pair = SocketPair(TlsClient('client', 'root', 13001), TcpServer(13000))

--- a/tests/test-server-metrics-bridge.py
+++ b/tests/test-server-metrics-bridge.py
@@ -27,14 +27,10 @@ if __name__ == "__main__":
     server.start()
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['server',
-      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
-      '--keystore=server.p12',
-      '--cacert=root.crt',
-      '--allow-ou=client',
-      '--enable-pprof',
-      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
-      '--metrics-interval=1s',
+    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
+      '--target={0}:13002'.format(LOCALHOST), '--keystore=server.p12',
+      '--cacert=root.crt', '--allow-ou=client', '--enable-pprof',
+      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT), '--metrics-interval=1s',
       '--metrics-url=http://localhost:13080/post'])
 
     # wait for metrics to post

--- a/tests/test-server-metrics-graphite.py
+++ b/tests/test-server-metrics-graphite.py
@@ -21,12 +21,9 @@ if __name__ == "__main__":
     m.listen(1)
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['server',
-      '--proxy={0}:13001:{0}:13100'.format(LOCALHOST),
-      '--keystore=server.p12',
-      '--cacert=root.crt',
-      '--allow-ou=client',
-      '--metrics-interval=1s',
+    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
+      '--target={0}:13100'.format(LOCALHOST), '--keystore=server.p12',
+      '--cacert=root.crt', '--allow-ou=client', '--metrics-interval=1s',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
       '--metrics-graphite=localhost:13099'])
 

--- a/tests/test-server-metrics-graphite.py
+++ b/tests/test-server-metrics-graphite.py
@@ -28,7 +28,7 @@ if __name__ == "__main__":
       '--allow-ou=client',
       '--metrics-interval=1s',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
-      '--graphite=localhost:13099'])
+      '--metrics-graphite=localhost:13099'])
 
     # wait for metrics to be sent
     conn, addr = m.accept()

--- a/tests/test-server-rejects-invalid-ou-or-ca.py
+++ b/tests/test-server-rejects-invalid-ou-or-ca.py
@@ -20,12 +20,10 @@ if __name__ == "__main__":
     other_root.create_signed_cert('other_client1')
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['server',
-      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
-      '--keystore=server.p12',
+    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
+      '--target={0}:13002'.format(LOCALHOST), '--keystore=server.p12',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
-      '--cacert=root.crt',
-      '--allow-ou=client1'])
+      '--cacert=root.crt', '--allow-ou=client1'])
 
     # connect with client1, confirm that the tunnel is up
     pair = SocketPair(TlsClient('client1', 'root', 13001), TcpServer(13002))

--- a/tests/test-server-reload-broken-certificate.py
+++ b/tests/test-server-reload-broken-certificate.py
@@ -15,11 +15,9 @@ if __name__ == "__main__":
     root.create_signed_cert('client')
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['server',
-      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
-      '--keystore=server.p12',
-      '--cacert=root.crt',
-      '--allow-ou=client',
+    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
+      '--target={0}:13002'.format(LOCALHOST), '--keystore=server.p12',
+      '--cacert=root.crt', '--allow-ou=client',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
     # create connections with client

--- a/tests/test-server-reloads-certificate.py
+++ b/tests/test-server-reloads-certificate.py
@@ -16,11 +16,9 @@ if __name__ == "__main__":
     root.create_signed_cert('client')
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['server',
-      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
-      '--keystore=server.p12',
-      '--cacert=root.crt',
-      '--allow-ou=client',
+    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
+      '--target={0}:13002'.format(LOCALHOST), '--keystore=server.p12',
+      '--cacert=root.crt', '--allow-ou=client',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
     # create connections with client

--- a/tests/test-server-shutdown-sigterm.py
+++ b/tests/test-server-shutdown-sigterm.py
@@ -13,11 +13,9 @@ if __name__ == "__main__":
     root.create_signed_cert('client')
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['server',
-      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
-      '--keystore=server.p12',
-      '--cacert=root.crt',
-      '--allow-ou=client',
+    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
+      '--target={0}:13002'.format(LOCALHOST), '--keystore=server.p12',
+      '--cacert=root.crt', '--allow-ou=client',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
     # wait for startup

--- a/tests/test-server-shutdown-timeout.py
+++ b/tests/test-server-shutdown-timeout.py
@@ -13,12 +13,9 @@ if __name__ == "__main__":
     root.create_signed_cert('client')
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['server',
-      '--proxy={0}:13001:{0}:13002'.format(LOCALHOST),
-      '--keystore=server.p12',
-      '--cacert=root.crt',
-      '--allow-ou=client',
-      '--shutdown-timeout=1s',
+    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
+      '--target={0}:13002'.format(LOCALHOST), '--keystore=server.p12',
+      '--cacert=root.crt', '--allow-ou=client', '--shutdown-timeout=1s',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
     # wait for startup

--- a/tests/test-server-status-port-unix.py
+++ b/tests/test-server-status-port-unix.py
@@ -28,11 +28,9 @@ if __name__ == "__main__":
     tempdir = mkdtemp()
     path = os.path.join(tempdir, 'ghostunnel-status-socket')
 
-    ghostunnel = run_ghostunnel(['server',
-      '--proxy={0}:13001:unix:{1}'.format(LOCALHOST, path),
-      '--keystore=server.p12',
-      '--cacert=root.crt',
-      '--allow-ou=client',
+    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
+      '--target=unix:{0}'.format(path), '--keystore=server.p12',
+      '--cacert=root.crt', '--allow-ou=client',
       '--status=unix:{0}'.format(path)])
 
     # wait for startup

--- a/tests/test-server-status-port.py
+++ b/tests/test-server-status-port.py
@@ -17,11 +17,9 @@ if __name__ == "__main__":
 
     # start ghostunnel
     # hack: point target to STATUS_PORT so that /_status doesn't 503.
-    ghostunnel = run_ghostunnel(['server',
-      '--proxy={0}:13001:{0}:{1}'.format(LOCALHOST, STATUS_PORT),
-      '--keystore=server.p12',
-      '--cacert=root.crt',
-      '--allow-ou=client',
+    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
+      '--target={0}:{1}'.format(LOCALHOST, STATUS_PORT), '--keystore=server.p12',
+      '--cacert=root.crt', '--allow-ou=client',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
     urlopen = lambda path: urllib.request.urlopen(path, cafile='root.crt')

--- a/tests/test-server-tls-handshake-timeout.py
+++ b/tests/test-server-tls-handshake-timeout.py
@@ -21,7 +21,7 @@ if __name__ == "__main__":
       '--keystore=server.p12',
       '--cacert=root.crt',
       '--allow-ou=client',
-      '--timeout=1s',
+      '--connect-timeout=1s',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
     # connect but don't perform handshake

--- a/tests/test-server-tls-handshake-timeout.py
+++ b/tests/test-server-tls-handshake-timeout.py
@@ -16,12 +16,9 @@ if __name__ == "__main__":
     root.create_signed_cert('client')
 
     # start ghostunnel
-    ghostunnel = run_ghostunnel(['server',
-      '--proxy={0}:13000:{0}:13001'.format(LOCALHOST),
-      '--keystore=server.p12',
-      '--cacert=root.crt',
-      '--allow-ou=client',
-      '--connect-timeout=1s',
+    ghostunnel = run_ghostunnel(['server', '--listen={0}:13000'.format(LOCALHOST),
+      '--target={0}:13001'.format(LOCALHOST), '--keystore=server.p12',
+      '--cacert=root.crt', '--allow-ou=client', '--connect-timeout=1s',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
     # connect but don't perform handshake

--- a/tests/test-server-unix-socket-backend.py
+++ b/tests/test-server-unix-socket-backend.py
@@ -16,12 +16,9 @@ if __name__ == "__main__":
 
     # start ghostunnel
     socket = UnixServer()
-    ghostunnel = run_ghostunnel(['server',
-      '--proxy={0}:13001:unix:{1}'.format(LOCALHOST, socket.get_socket_path()),
-      '--keystore=server.p12',
-      '--cacert=root.crt',
-      '--allow-ou=client',
-      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
+    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
+      '--target=unix:{0}'.format(socket.get_socket_path()), '--keystore=server.p12',
+      '--cacert=root.crt', '--allow-ou=client', '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 
     # connect with client, confirm that the tunnel is up
     pair = SocketPair(TlsClient('client', 'root', 13001), socket)

--- a/tls.go
+++ b/tls.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 	"sync/atomic"
 	"time"
 	"unsafe"
@@ -177,8 +178,8 @@ func buildConfig(caBundlePath string) (*tls.Config, error) {
 	// * We list AES-128 ahead of AES-256 for performance reasons.
 
 	suites := []uint16{}
-	for _, suite := range *enabledCipherSuites {
-		ciphers, ok := cipherSuites[suite]
+	for _, suite := range strings.Split(*enabledCipherSuites, ",") {
+		ciphers, ok := cipherSuites[strings.TrimSpace(suite)]
 		if !ok {
 			return nil, fmt.Errorf("invalid cipher suite %s selected", suite)
 		}

--- a/tls_test.go
+++ b/tls_test.go
@@ -179,7 +179,7 @@ func TestBuildConfig(t *testing.T) {
 	defer os.Remove(tmpCaBundle.Name())
 	defer os.Remove(tmpKeystoreNoPrivKey.Name())
 
-	*enabledCipherSuites = []string{"AES", "CHACHA"}
+	*enabledCipherSuites = "AES,CHACHA"
 	conf, err := buildConfig(tmpCaBundle.Name())
 	assert.Nil(t, err, "should be able to build TLS config")
 	assert.NotNil(t, conf.RootCAs, "config must have CA certs")
@@ -208,20 +208,20 @@ func TestBuildConfig(t *testing.T) {
 }
 
 func TestCipherSuitePreference(t *testing.T) {
-	*enabledCipherSuites = []string{"XYZ"}
+	*enabledCipherSuites = "XYZ"
 	conf, err := buildConfig("")
 	assert.NotNil(t, err, "should not be able to build TLS config with invalid cipher suite option")
 
-	*enabledCipherSuites = []string{}
+	*enabledCipherSuites = ""
 	conf, err = buildConfig("")
 	assert.NotNil(t, err, "should not be able to build TLS config wihout cipher suite selection")
 
-	*enabledCipherSuites = []string{"CHACHA", "AES"}
+	*enabledCipherSuites = "CHACHA,AES"
 	conf, err = buildConfig("")
 	assert.Nil(t, err, "should be able to build TLS config")
 	assert.True(t, conf.CipherSuites[0] == tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305, "expecting ChaCha20")
 
-	*enabledCipherSuites = []string{"AES", "CHACHA"}
+	*enabledCipherSuites = "AES,CHACHA"
 	conf, err = buildConfig("")
 	assert.Nil(t, err, "should be able to build TLS config")
 	assert.True(t, conf.CipherSuites[0] == tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, "expecting AES")


### PR DESCRIPTION
I'd like to merge and then release this as 1.1.0:
* Remove subprocess management (done in other pull request)
* Rename --timeout  to --connect-timeout to be clearer about purpose
* Rename --graphite to --metrics-graphite to be consistent with other metrics flags
* Bring back --listen and --target since we're not doing multi-connect
* Make the cipher-suites flag take a comma-separated string, it's less confusing
