### PR TITLE
[WIP] Disable PKCS11 without CGO

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ before_install:
   - sudo softhsm --id 01 --slot 0 --label ghostunnel-pkcs11-test --import test-keys/server.pkcs8.key --pin 1234
 
 install:
+  - CGO_ENABLED=0 go build .
   - CGO_ENABLED=1 go build .
   - docker build -t square/ghostunnel .
 

--- a/README.md
+++ b/README.md
@@ -247,7 +247,8 @@ For information on profiling via pprof, see the
 Ghostunnel has experimental support for loading private keys from PKCS11
 modules, which should work with any hardware security module that exposes a
 PKCS11 interface. An easy way to test the PKCS11 interface for development
-purposes is with [SoftHSM][softhsm].
+purposes is with [SoftHSM][softhsm]. Note that for PKCS11 support to work,
+you must compile with `CGO_ENABLED=1`.
 
 [softhsm]: https://github.com/opendnssec/SoftHSMv2
 

--- a/main.go
+++ b/main.go
@@ -71,9 +71,6 @@ var (
 	keystorePass        = app.Flag("storepass", "Password for certificate and keystore (optional).").PlaceHolder("PASS").String()
 	caBundlePath        = app.Flag("cacert", "Path to CA bundle file (PEM/X509). Uses system trust store by default.").String()
 	enabledCipherSuites = app.Flag("cipher-suites", "Set of cipher suites to enable, comma-separated, in order of preference (AES, CHACHA).").Default("AES,CHACHA").String()
-	pkcs11Module        = app.Flag("pkcs11-module", "Path to PKCS11 module (SO) file (optional)").PlaceHolder("PATH").ExistingFile()
-	pkcs11TokenLabel    = app.Flag("pkcs11-token-label", "Token label for slot/key in PKCS11 module (optional)").PlaceHolder("LABEL").String()
-	pkcs11PIN           = app.Flag("pkcs11-pin", "PIN code for slot/key in PKCS11 module (optional)").PlaceHolder("PIN").String()
 
 	// Reloading and timeouts
 	timedReload     = app.Flag("timed-reload", "Reload keystores every given interval (e.g. 300s), refresh listener/client on changes.").PlaceHolder("DURATION").Duration()
@@ -242,7 +239,7 @@ func run(args []string) error {
 		go watchFiles([]string{*keystorePath}, *timedReload, watcher)
 	}
 
-	cert, err := buildCertificate(*keystorePath, *keystorePass, *pkcs11Module, *pkcs11TokenLabel, *pkcs11PIN)
+	cert, err := buildCertificate(*keystorePath, *keystorePass)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: unable to load certificates: %s\n", err)
 		return err

--- a/tls.go
+++ b/tls.go
@@ -29,7 +29,6 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/letsencrypt/pkcs11key"
 	certigo "github.com/square/certigo/lib"
 )
 
@@ -149,7 +148,7 @@ func (c *certificate) reloadFromPKCS11() error {
 		old, _ := c.getCertificate(nil)
 		certAndKey.PrivateKey = old.PrivateKey
 	} else {
-		privateKey, err := pkcs11key.New(c.pkcs11Module, c.pkcs11TokenLabel, c.pkcs11PIN, certAndKey.Leaf.PublicKey)
+		privateKey, err := newpkcs11(c.pkcs11Module, c.pkcs11TokenLabel, c.pkcs11PIN, certAndKey.Leaf.PublicKey)
 		if err != nil {
 			return err
 		}

--- a/tls_cgo.go
+++ b/tls_cgo.go
@@ -1,0 +1,11 @@
+// +build cgo
+
+package main
+
+import "crypto"
+import "github.com/letsencrypt/pkcs11key"
+
+
+func newpkcs11(module, tokenLabel, pin string, pubkey crypto.PublicKey) (interface{}, error) {
+	return pkcs11key.New(module, tokenLabel, pin, pubkey)
+}

--- a/tls_cgo.go
+++ b/tls_cgo.go
@@ -2,10 +2,22 @@
 
 package main
 
-import "crypto"
-import "github.com/letsencrypt/pkcs11key"
+import (
+	"crypto"
 
+	"github.com/letsencrypt/pkcs11key"
+)
 
-func newpkcs11(module, tokenLabel, pin string, pubkey crypto.PublicKey) (interface{}, error) {
-	return pkcs11key.New(module, tokenLabel, pin, pubkey)
+var (
+	pkcs11Module     = app.Flag("pkcs11-module", "Path to PKCS11 module (SO) file (optional)").PlaceHolder("PATH").ExistingFile()
+	pkcs11TokenLabel = app.Flag("pkcs11-token-label", "Token label for slot/key in PKCS11 module (optional)").PlaceHolder("LABEL").String()
+	pkcs11PIN        = app.Flag("pkcs11-pin", "PIN code for slot/key in PKCS11 module (optional)").PlaceHolder("PIN").String()
+)
+
+func newPKCS11(pubkey crypto.PublicKey) (crypto.PrivateKey, error) {
+	return pkcs11key.New(*pkcs11Module, *pkcs11TokenLabel, *pkcs11PIN, pubkey)
+}
+
+func hasPKCS11() bool {
+	return *pkcs11Module != ""
 }

--- a/tls_no_cgo.go
+++ b/tls_no_cgo.go
@@ -1,0 +1,9 @@
+// +build !cgo
+
+package main
+
+import "fmt"
+
+func newpkcs11(module, tokenlabel, pin, pubkey interface{}) (interface{}, error) {
+	return nil, fmt.Errorf("PKCS11 unavailable when compiled without CGO")
+}

--- a/tls_no_cgo.go
+++ b/tls_no_cgo.go
@@ -2,8 +2,15 @@
 
 package main
 
-import "fmt"
+import (
+	"crypto"
+	"fmt"
+)
 
-func newpkcs11(module, tokenlabel, pin, pubkey interface{}) (interface{}, error) {
+func newPKCS11(pubkey crypto.PublicKey) (crypto.PrivateKey, error) {
 	return nil, fmt.Errorf("PKCS11 unavailable when compiled without CGO")
+}
+
+func hasPKCS11() bool {
+	return false
 }

--- a/tls_no_cgo.go
+++ b/tls_no_cgo.go
@@ -4,11 +4,11 @@ package main
 
 import (
 	"crypto"
-	"fmt"
+	"errors"
 )
 
 func newPKCS11(pubkey crypto.PublicKey) (crypto.PrivateKey, error) {
-	return nil, fmt.Errorf("PKCS11 unavailable when compiled without CGO")
+	panic(errors.New("PKCS11 unavailable when compiled without CGO support"))
 }
 
 func hasPKCS11() bool {

--- a/tls_test.go
+++ b/tls_test.go
@@ -194,19 +194,19 @@ func TestBuildConfig(t *testing.T) {
 	assert.Nil(t, conf, "conf with invalid params should be nil")
 	assert.NotNil(t, err, "should reject invalid CA cert bundle")
 
-	cert, err := buildCertificate(tmpKeystore.Name(), "totes invalid", "", "", "")
+	cert, err := buildCertificate(tmpKeystore.Name(), "totes invalid")
 	assert.Nil(t, cert, "cert with invalid params should be nil")
 	assert.NotNil(t, err, "should reject invalid keystore pass")
 
-	cert, err = buildCertificate("does-not-exist", testKeystorePassword, "", "", "")
+	cert, err = buildCertificate("does-not-exist", testKeystorePassword)
 	assert.Nil(t, cert, "cert with invalid params should be nil")
 	assert.NotNil(t, err, "should reject missing keystore (not found)")
 
-	cert, err = buildCertificate(tmpKeystoreNoPrivKey.Name(), "", "", "", "")
+	cert, err = buildCertificate(tmpKeystoreNoPrivKey.Name(), "")
 	assert.Nil(t, cert, "cert with invalid params should be nil")
-	assert.NotNil(t, err, "should reject invalid keystore (no private key)", "", "", "")
+	assert.NotNil(t, err, "should reject invalid keystore (no private key)")
 
-	cert, err = buildCertificate("/dev/null", "", "", "", "")
+	cert, err = buildCertificate("/dev/null", "")
 	assert.Nil(t, cert, "cert with invalid params should be nil")
 	assert.NotNil(t, err, "should reject invalid keystore (empty)")
 }

--- a/tls_test.go
+++ b/tls_test.go
@@ -240,7 +240,7 @@ func TestReload(t *testing.T) {
 
 	defer os.Remove(tmpKeystore.Name())
 
-	c, err := buildCertificate(tmpKeystore.Name(), testKeystorePassword, "", "", "")
+	c, err := buildCertificate(tmpKeystore.Name(), testKeystorePassword)
 	assert.Nil(t, err, "should be able to build certificate")
 
 	c.reload()


### PR DESCRIPTION
This makes the build pass with CGO_ENABLED=0.
With CGO enabled, I can't compile on android.  Since I don't need PKCS11
here, I figure this is a reasonable alternative.

This PR isn't done -- opening so I can get some Travis builds to make sure it still works with CGO.