### PR TITLE
Run integration tests in Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+---
+
 language: go
 
 sudo: required
@@ -6,37 +8,25 @@ dist: trusty
 services:
   - docker
 
-matrix:
-  fast_finish: true
-  allow_failures:
-    - go: master
-
 go:
   - 1.8
   - 1.9
-  - master
 
 before_install:
-  - pyenv versions
-  - pyenv global 3.5
-  - /usr/bin/env python3 --version
-  - sudo apt-get install -y netcat softhsm
-  - go get github.com/wadey/gocovmerge
+  - sudo apt-get update
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
   - go get github.com/mattn/goveralls
-  - go get golang.org/x/tools/cmd/cover
-  - sudo mkdir -p /var/lib/lib/softhsm
-  - sudo chown -R $USER:$USER /etc/softhsm
-  - sudo chown -R $USER:$USER /var/lib/lib/softhsm
-  - sudo softhsm --init-token --slot 0 --label ghostunnel-pkcs11-test --so-pin 1234 --pin 1234
-  - sudo softhsm --id 01 --slot 0 --label ghostunnel-pkcs11-test --import test-keys/server.pkcs8.key --pin 1234
 
 install:
+  # Ensure we can build with/without CGO
   - CGO_ENABLED=0 go build .
   - CGO_ENABLED=1 go build .
-  - docker build -t square/ghostunnel .
+  # Build docker images
+  - make docker-build
+  - GO_VERSION=${TRAVIS_GO_VERSION}-stretch make docker-test-build
 
 script:
-  - GHOSTUNNEL_TEST_PKCS11=true PKCS11_MODULE=/usr/lib/softhsm/libsofthsm.so PKCS11_LABEL=ghostunnel-pkcs11-test PKCS11_PIN=1234 make test
+  - make docker-test-run
 
 after_success:
   - $HOME/gopath/bin/goveralls -coverprofile coverage-merged.out -service=travis-ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,6 @@
 #
 # To run ghostunnel from the image (for example):
 #     docker run --rm squareup/ghostunnel ghostunnel --version
-#
-# For an example image that builds on top of this, check out the docker subdirectory.
 
 FROM golang:alpine
 

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -1,0 +1,38 @@
+# Dockerfile for running integration tests, includes PKCS11/SoftHSM setup. 
+# 
+# Build image:
+#     docker build --build-arg GO_VERSION=[VERSION] -t squareup/ghostunnel-test -f Dockerfile-test .
+#
+# Run integration tests:
+#     docker run -v /dev/log:/dev/log -v $PWD:/go/src/github.com/square/ghostunnel squareup/ghostunnel-test
+
+ARG GO_VERSION
+
+FROM golang:${GO_VERSION}
+
+MAINTAINER Cedric Staub "cs@squareup.com"
+
+# Install build dependencies
+RUN apt-get update && \
+    apt-get install --yes build-essential libtool python3.5 netcat softhsm2 rsyslog && \
+    mkdir -p /etc/softhsm /var/lib/softhsm/tokens /go/src/github.com/square/ghostunnel && \
+    ln -s /usr/bin/python3.5 /usr/bin/python3 && \
+    go get github.com/wadey/gocovmerge && \
+    go get golang.org/x/tools/cmd/cover
+
+WORKDIR /go/src/github.com/square/ghostunnel
+
+# Setup SoftHSM for testing PKCS11 support
+# Instruct PKCS11 integration test to run
+ENV GHOSTUNNEL_TEST_PKCS11=true
+
+# Set params for PKCS11 module
+ENV PKCS11_MODULE=/usr/lib/softhsm/libsofthsm2.so
+ENV PKCS11_LABEL=ghostunnel-pkcs11-test
+ENV PKCS11_PIN=1234
+
+# Set SoftHSM config file
+ENV SOFTHSM2_CONF=/etc/softhsm/softhsm2.conf
+
+ENTRYPOINT ["/usr/bin/make"]
+CMD ["softhsm-import", "test"]

--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,19 @@ unit:
 $(INTEGRATION_TESTS): ghostunnel.test
 	@cd tests && ./runner.py $@
 
-.PHONY: $(INTEGRATION_TESTS) test unit
+softhsm-import:
+	softhsm2-util --init-token --slot 0 --label ${PKCS11_LABEL} --so-pin ${PKCS11_PIN} --pin ${PKCS11_PIN}
+	softhsm2-util --id 01 --token ${PKCS11_LABEL} --label ${PKCS11_LABEL} --import test-keys/server.pkcs8.key --so-pin ${PKCS11_PIN} --pin ${PKCS11_PIN}
+
+docker-build:
+	docker build -t squareup/ghostunnel .
+
+docker-test-build:
+	docker build --build-arg GO_VERSION=${GO_VERSION} -t squareup/ghostunnel-test -f Dockerfile-test .
+
+docker-test-run:
+	docker run -v /dev/log:/dev/log -v ${PWD}:/go/src/github.com/square/ghostunnel squareup/ghostunnel-test
+
+docker-test: docker-test-build docker-test-run
+
+.PHONY: $(INTEGRATION_TESTS) test unit softhsm-import docker-build docker-test-build docker-test-run docker-test

--- a/README.md
+++ b/README.md
@@ -83,8 +83,11 @@ managing vendored dependencies.
 
 To run tests:
 
-    # Run unit & integration tests
+    # Option 1: run unit & integration tests locally
     make test
+
+    # Option 2: run unit & integration tests in a Docker container
+    GO_VERSION=1.9 make docker-test
 
     # Open coverage information in browser
     go tool cover -html coverage-merged.out


### PR DESCRIPTION
Adds `Dockerfile-test` which builds a base image for running Ghostunnel integration tests, including PKCS11 tests via SoftHSM. This makes the integration tests a bit more predictable and allows for running them locally without having to set up SoftHSM and such. Also takes some complexity out of the Travis-CI build file and puts it into the Dockerfile. 