### PR TITLE
Clean before running integration tests in docker

### DIFF
--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -35,4 +35,4 @@ ENV PKCS11_PIN=1234
 ENV SOFTHSM2_CONF=/etc/softhsm/softhsm2.conf
 
 ENTRYPOINT ["/usr/bin/make"]
-CMD ["softhsm-import", "test"]
+CMD ["clean", "softhsm-import", "test"]

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ INTEGRATION_TESTS := $(shell find tests -name 'test-*.py' -exec basename {} .py 
 ghostunnel.test: $(SOURCE_FILES)
 	go test -c -covermode=count -coverpkg .
 
+clean:
+	rm -rf *.out */*.out ghostunnel.test tests/__pycache__
+
 test: unit $(INTEGRATION_TESTS)
 	gocovmerge *.out */*.out > coverage-merged.out
 	@echo "PASS"
@@ -30,4 +33,4 @@ docker-test-run:
 
 docker-test: docker-test-build docker-test-run
 
-.PHONY: $(INTEGRATION_TESTS) test unit softhsm-import docker-build docker-test-build docker-test-run docker-test
+.PHONY: $(INTEGRATION_TESTS) test unit softhsm-import docker-build docker-test-build docker-test-run docker-test clean


### PR DESCRIPTION
Clean before running integration tests in docker. Avoids failures from switching back and forth between running tests locally on a mac and running them in docker/linux.