### PR TITLE
Better logging and flag validation

### DIFF
--- a/tests/test-server-status-port-unix.py
+++ b/tests/test-server-status-port-unix.py
@@ -5,6 +5,7 @@
 from subprocess import Popen
 from common import *
 from tempfile import mkdtemp
+from shutil import rmtree
 import urllib.request, urllib.error, urllib.parse, socket, ssl, time, os, signal, json, sys, http.client
 
 class UnixHTTPConnection(http.client.HTTPConnection):
@@ -52,5 +53,5 @@ if __name__ == "__main__":
     print_ok("OK")
   finally:
     terminate(ghostunnel)
-    os.rmdir(tempdir)
+    rmtree(tempdir)
       


### PR DESCRIPTION
* Validate that the schema of connect-proxy is http/https (http_dialer is unhappy otherwise)
* Improve logging a big, show source/target/proxy addresses and certificate info in the log output
* Don't log cipher suites in `buildConfig` because it gets called multiple times and duplicates the output