### PR TITLE
Better error handling for syslog failures

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -83,6 +83,7 @@ func TestIntegrationMain(t *testing.T) {
 func TestInitLoggerSyslog(t *testing.T) {
 	*useSyslog = true
 	initLogger()
+	*useSyslog = false
 	assert.NotNil(t, logger, "logger should never be nil after init")
 }
 


### PR DESCRIPTION
Better error handling for syslog failures, to make unit tests run in containers (or container-based IDEs like c9.io) without having to run/bind syslog somewhere. 