### PR TITLE
Removing a waitgroup that is not used

### DIFF
--- a/main.go
+++ b/main.go
@@ -344,9 +344,6 @@ func serverListen(context *Context) error {
 		return err
 	}
 
-	handlers := &sync.WaitGroup{}
-	handlers.Add(1)
-
 	proxy := &proxy{
 		quit:     0,
 		listener: tls.NewListener(listener, config),


### PR DESCRIPTION
The `handlers` waitgroup looks as though it was copy/pasted along with some other code during a previous change, but the actual waitgroup was moved to the proxy instance.