### PR TITLE
Disable client cert checking for 'server --allow-all'

### DIFF
--- a/tls.go
+++ b/tls.go
@@ -252,7 +252,13 @@ func buildConfig(caBundlePath string) (*tls.Config, error) {
 
 		PreferServerCipherSuites: true,
 
-		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientAuth: func() tls.ClientAuthType {
+			if *serverAllowAll {
+				return tls.NoClientCert
+			} else {
+				return tls.RequireAndVerifyClientCert
+			}
+		}(),
 		MinVersion:   tls.VersionTLS12,
 		CipherSuites: suites,
 		CurvePreferences: []tls.CurveID{


### PR DESCRIPTION
In server mode with --allow-all flag set, client cert checking should be disabled. Browser TLS connections usually do not submit client certificate. Otherwise, browsers have no way to establish TLS (https or wss) connection via ghostunnel.