### PR TITLE
Basic Windows support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,38 @@
+version: '{build}-{branch}'
+
+os: 'Visual Studio 2015'
+
+environment:
+  matrix:
+    - ARCH: x64
+      MSYS2_ARCH: x86_64
+      MSYS2_DIR: msys64
+      MSYSTEM: MINGW64
+      GOPATH: c:\gopath
+      GOARCH: amd64
+      CGO_ENABLED: 1
+    - ARCH: x86
+      MSYS2_ARCH: i686
+      MSYS2_DIR: msys64
+      MSYSTEM: MINGW32
+      GOPATH: c:\gopath
+      GOARCH: 386
+      CGO_ENABLED: 1
+
+branches:
+  only:
+    - master
+
+clone_folder: C:\gopath\src\github.com\square\ghostunnel
+
+before_build:
+  # Go paths
+  - set PATH=C:\go19\bin;C:\%GOPATH%\bin;%PATH%
+  # MSYS paths
+  - set PATH=C:\%MSYS2_DIR%\%MSYSTEM%\bin;C:\%MSYS2_DIR%\usr\bin;%PATH%
+  # Install build deps
+  - bash -lc "for n in `seq 1 3`; do pacman --noconfirm -Syyuu && break || sleep 15; done"
+  - bash -lc "for n in `seq 1 3`; do pacman --noconfirm -S mingw-w64-%MSYS2_ARCH%-libtool && break || sleep 15; done"
+
+build_script:
+  - go build -o ghostunnel.exe -i .

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -36,3 +36,4 @@ before_build:
 
 build_script:
   - go build -o ghostunnel.exe -i .
+  - go test -v .

--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@
 *.crt
 *.out
 ghostunnel
+ghostunnel.exe
 ghostunnel.test
 __pycache__

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,14 +34,20 @@ before_install:
   - go get github.com/mattn/goveralls
 
 install:
+  # Compile with CGO on/off for Linux
   - CGO_ENABLED=0 go build -o ghostunnel-${TRAVIS_TAG}-linux-amd64-without-pkcs11 .
   - CGO_ENABLED=1 go build -o ghostunnel-${TRAVIS_TAG}-linux-amd64-with-pkcs11 .
+  # Cross-compile for various platforms (can't do PKCS11 here, CGO cross-compile is tricky)
   - GOOS=darwin CGO_ENABLED=0 go build -o ghostunnel-${TRAVIS_TAG}-darwin-amd64-without-pkcs11 .
   - GOOS=freebsd CGO_ENABLED=0 go build -o ghostunnel-${TRAVIS_TAG}-freebsd-amd64-without-pkcs11 .
+  - GOOS=windows CGO_ENABLED=0 go build -o ghostunnel-${TRAVIS_TAG}-windows-amd64-without-pkcs11.exe .
+  # Generate checksums for GitHub release binaries
   - 'for file in ghostunnel-${TRAVIS_TAG}-*; do sha256sum ${file} > ${file}.sha256sum; done'
+  # Build Docker container
   - make docker-build
 
 script:
+  # Run tests inside Docker, guarantees that we have proper PKCS11 test setup
   - GO_VERSION=${TRAVIS_GO_VERSION} make docker-test
 
 after_success:

--- a/main_test.go
+++ b/main_test.go
@@ -82,9 +82,19 @@ func TestIntegrationMain(t *testing.T) {
 
 func TestInitLoggerSyslog(t *testing.T) {
 	*useSyslog = true
-	initLogger()
-	*useSyslog = false
+	originalLogger := logger
+	err := initLogger()
+	updatedLogger := logger
+	if err != nil {
+		// Tests running in containers often don't have access to syslog,
+		// so we can't depend on syslog being available for testing. If we
+		// get an error from the syslog setup we just warn and skip test.
+		t.Logf("Error setting up syslog for test, skipping: %s", err)
+		t.SkipNow()
+	}
+	assert.NotEqual(t, originalLogger, updatedLogger, "should have updated logger object")
 	assert.NotNil(t, logger, "logger should never be nil after init")
+	*useSyslog = false
 }
 
 func TestPanicOnError(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -82,6 +82,7 @@ func TestIntegrationMain(t *testing.T) {
 
 func TestInitLoggerSyslog(t *testing.T) {
 	*useSyslog = true
+	defer func() { *useSyslog = false }()
 	originalLogger := logger
 	err := initLogger()
 	updatedLogger := logger
@@ -91,10 +92,10 @@ func TestInitLoggerSyslog(t *testing.T) {
 		// get an error from the syslog setup we just warn and skip test.
 		t.Logf("Error setting up syslog for test, skipping: %s", err)
 		t.SkipNow()
+		return
 	}
 	assert.NotEqual(t, originalLogger, updatedLogger, "should have updated logger object")
 	assert.NotNil(t, logger, "logger should never be nil after init")
-	*useSyslog = false
 }
 
 func TestPanicOnError(t *testing.T) {

--- a/signals_unix.go
+++ b/signals_unix.go
@@ -1,0 +1,29 @@
+// +build !windows
+
+/*-
+ * Copyright 2015 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+var (
+	shutdownSignals = []os.Signal{syscall.SIGINT, syscall.SIGTERM}
+	refreshSignals  = []os.Signal{syscall.SIGUSR1}
+)

--- a/signals_windows.go
+++ b/signals_windows.go
@@ -1,0 +1,28 @@
+// +build windows
+
+/*-
+ * Copyright 2018 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"os"
+)
+
+var (
+	shutdownSignals = []os.Signal{os.Interrupt}
+	refreshSignals  = []os.Signal{ /* Not supported on Windows */ }
+)

--- a/status_test.go
+++ b/status_test.go
@@ -52,7 +52,7 @@ func (c fakeConn) SetWriteDeadline(t time.Time) error {
 }
 
 func dummyDial() (net.Conn, error) {
-	f, err := os.Open("/dev/null")
+	f, err := os.Open(os.DevNull)
 	panicOnError(err)
 	return fakeConn{f}, nil
 }

--- a/tls_cgo.go
+++ b/tls_cgo.go
@@ -1,5 +1,21 @@
 // +build cgo
 
+/*-
+ * Copyright 2018 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package main
 
 import (

--- a/tls_no_cgo.go
+++ b/tls_no_cgo.go
@@ -1,5 +1,21 @@
 // +build !cgo
 
+/*-
+ * Copyright 2018 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package main
 
 import (

--- a/vendor/github.com/hashicorp/go-syslog/LICENSE
+++ b/vendor/github.com/hashicorp/go-syslog/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Armon Dadgar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/hashicorp/go-syslog/builtin.go
+++ b/vendor/github.com/hashicorp/go-syslog/builtin.go
@@ -1,0 +1,214 @@
+// This file is taken from the log/syslog in the standard lib.
+// However, there is a bug with overwhelming syslog that causes writes
+// to block indefinitely. This is fixed by adding a write deadline.
+//
+// +build !windows,!nacl,!plan9
+
+package gsyslog
+
+import (
+	"errors"
+	"fmt"
+	"log/syslog"
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+const severityMask = 0x07
+const facilityMask = 0xf8
+const localDeadline = 20 * time.Millisecond
+const remoteDeadline = 50 * time.Millisecond
+
+// A builtinWriter is a connection to a syslog server.
+type builtinWriter struct {
+	priority syslog.Priority
+	tag      string
+	hostname string
+	network  string
+	raddr    string
+
+	mu   sync.Mutex // guards conn
+	conn serverConn
+}
+
+// This interface and the separate syslog_unix.go file exist for
+// Solaris support as implemented by gccgo.  On Solaris you can not
+// simply open a TCP connection to the syslog daemon.  The gccgo
+// sources have a syslog_solaris.go file that implements unixSyslog to
+// return a type that satisfies this interface and simply calls the C
+// library syslog function.
+type serverConn interface {
+	writeString(p syslog.Priority, hostname, tag, s, nl string) error
+	close() error
+}
+
+type netConn struct {
+	local bool
+	conn  net.Conn
+}
+
+// New establishes a new connection to the system log daemon.  Each
+// write to the returned writer sends a log message with the given
+// priority and prefix.
+func newBuiltin(priority syslog.Priority, tag string) (w *builtinWriter, err error) {
+	return dialBuiltin("", "", priority, tag)
+}
+
+// Dial establishes a connection to a log daemon by connecting to
+// address raddr on the specified network.  Each write to the returned
+// writer sends a log message with the given facility, severity and
+// tag.
+// If network is empty, Dial will connect to the local syslog server.
+func dialBuiltin(network, raddr string, priority syslog.Priority, tag string) (*builtinWriter, error) {
+	if priority < 0 || priority > syslog.LOG_LOCAL7|syslog.LOG_DEBUG {
+		return nil, errors.New("log/syslog: invalid priority")
+	}
+
+	if tag == "" {
+		tag = os.Args[0]
+	}
+	hostname, _ := os.Hostname()
+
+	w := &builtinWriter{
+		priority: priority,
+		tag:      tag,
+		hostname: hostname,
+		network:  network,
+		raddr:    raddr,
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	err := w.connect()
+	if err != nil {
+		return nil, err
+	}
+	return w, err
+}
+
+// connect makes a connection to the syslog server.
+// It must be called with w.mu held.
+func (w *builtinWriter) connect() (err error) {
+	if w.conn != nil {
+		// ignore err from close, it makes sense to continue anyway
+		w.conn.close()
+		w.conn = nil
+	}
+
+	if w.network == "" {
+		w.conn, err = unixSyslog()
+		if w.hostname == "" {
+			w.hostname = "localhost"
+		}
+	} else {
+		var c net.Conn
+		c, err = net.DialTimeout(w.network, w.raddr, remoteDeadline)
+		if err == nil {
+			w.conn = &netConn{conn: c}
+			if w.hostname == "" {
+				w.hostname = c.LocalAddr().String()
+			}
+		}
+	}
+	return
+}
+
+// Write sends a log message to the syslog daemon.
+func (w *builtinWriter) Write(b []byte) (int, error) {
+	return w.writeAndRetry(w.priority, string(b))
+}
+
+// Close closes a connection to the syslog daemon.
+func (w *builtinWriter) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.conn != nil {
+		err := w.conn.close()
+		w.conn = nil
+		return err
+	}
+	return nil
+}
+
+func (w *builtinWriter) writeAndRetry(p syslog.Priority, s string) (int, error) {
+	pr := (w.priority & facilityMask) | (p & severityMask)
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.conn != nil {
+		if n, err := w.write(pr, s); err == nil {
+			return n, err
+		}
+	}
+	if err := w.connect(); err != nil {
+		return 0, err
+	}
+	return w.write(pr, s)
+}
+
+// write generates and writes a syslog formatted string. The
+// format is as follows: <PRI>TIMESTAMP HOSTNAME TAG[PID]: MSG
+func (w *builtinWriter) write(p syslog.Priority, msg string) (int, error) {
+	// ensure it ends in a \n
+	nl := ""
+	if !strings.HasSuffix(msg, "\n") {
+		nl = "\n"
+	}
+
+	err := w.conn.writeString(p, w.hostname, w.tag, msg, nl)
+	if err != nil {
+		return 0, err
+	}
+	// Note: return the length of the input, not the number of
+	// bytes printed by Fprintf, because this must behave like
+	// an io.Writer.
+	return len(msg), nil
+}
+
+func (n *netConn) writeString(p syslog.Priority, hostname, tag, msg, nl string) error {
+	if n.local {
+		// Compared to the network form below, the changes are:
+		//	1. Use time.Stamp instead of time.RFC3339.
+		//	2. Drop the hostname field from the Fprintf.
+		timestamp := time.Now().Format(time.Stamp)
+		n.conn.SetWriteDeadline(time.Now().Add(localDeadline))
+		_, err := fmt.Fprintf(n.conn, "<%d>%s %s[%d]: %s%s",
+			p, timestamp,
+			tag, os.Getpid(), msg, nl)
+		return err
+	}
+	timestamp := time.Now().Format(time.RFC3339)
+	n.conn.SetWriteDeadline(time.Now().Add(remoteDeadline))
+	_, err := fmt.Fprintf(n.conn, "<%d>%s %s %s[%d]: %s%s",
+		p, timestamp, hostname,
+		tag, os.Getpid(), msg, nl)
+	return err
+}
+
+func (n *netConn) close() error {
+	return n.conn.Close()
+}
+
+// unixSyslog opens a connection to the syslog daemon running on the
+// local machine using a Unix domain socket.
+func unixSyslog() (conn serverConn, err error) {
+	logTypes := []string{"unixgram", "unix"}
+	logPaths := []string{"/dev/log", "/var/run/syslog", "/var/run/log"}
+	for _, network := range logTypes {
+		for _, path := range logPaths {
+			conn, err := net.DialTimeout(network, path, localDeadline)
+			if err != nil {
+				continue
+			} else {
+				return &netConn{conn: conn, local: true}, nil
+			}
+		}
+	}
+	return nil, errors.New("Unix syslog delivery error")
+}

--- a/vendor/github.com/hashicorp/go-syslog/syslog.go
+++ b/vendor/github.com/hashicorp/go-syslog/syslog.go
@@ -1,0 +1,27 @@
+package gsyslog
+
+// Priority maps to the syslog priority levels
+type Priority int
+
+const (
+	LOG_EMERG Priority = iota
+	LOG_ALERT
+	LOG_CRIT
+	LOG_ERR
+	LOG_WARNING
+	LOG_NOTICE
+	LOG_INFO
+	LOG_DEBUG
+)
+
+// Syslogger interface is used to write log messages to syslog
+type Syslogger interface {
+	// WriteLevel is used to write a message at a given level
+	WriteLevel(Priority, []byte) error
+
+	// Write is used to write a message at the default level
+	Write([]byte) (int, error)
+
+	// Close is used to close the connection to the logger
+	Close() error
+}

--- a/vendor/github.com/hashicorp/go-syslog/unix.go
+++ b/vendor/github.com/hashicorp/go-syslog/unix.go
@@ -1,0 +1,123 @@
+// +build linux darwin dragonfly freebsd netbsd openbsd solaris
+
+package gsyslog
+
+import (
+	"fmt"
+	"log/syslog"
+	"strings"
+)
+
+// builtinLogger wraps the Golang implementation of a
+// syslog.Writer to provide the Syslogger interface
+type builtinLogger struct {
+	*builtinWriter
+}
+
+// NewLogger is used to construct a new Syslogger
+func NewLogger(p Priority, facility, tag string) (Syslogger, error) {
+	fPriority, err := facilityPriority(facility)
+	if err != nil {
+		return nil, err
+	}
+	priority := syslog.Priority(p) | fPriority
+	l, err := newBuiltin(priority, tag)
+	if err != nil {
+		return nil, err
+	}
+	return &builtinLogger{l}, nil
+}
+
+// DialLogger is used to construct a new Syslogger that establishes connection to remote syslog server
+func DialLogger(network, raddr string, p Priority, facility, tag string) (Syslogger, error) {
+	fPriority, err := facilityPriority(facility)
+	if err != nil {
+		return nil, err
+	}
+
+	priority := syslog.Priority(p) | fPriority
+
+	l, err := dialBuiltin(network, raddr, priority, tag)
+	if err != nil {
+		return nil, err
+	}
+
+	return &builtinLogger{l}, nil
+}
+
+// WriteLevel writes out a message at the given priority
+func (b *builtinLogger) WriteLevel(p Priority, buf []byte) error {
+	var err error
+	m := string(buf)
+	switch p {
+	case LOG_EMERG:
+		_, err = b.writeAndRetry(syslog.LOG_EMERG, m)
+	case LOG_ALERT:
+		_, err = b.writeAndRetry(syslog.LOG_ALERT, m)
+	case LOG_CRIT:
+		_, err = b.writeAndRetry(syslog.LOG_CRIT, m)
+	case LOG_ERR:
+		_, err = b.writeAndRetry(syslog.LOG_ERR, m)
+	case LOG_WARNING:
+		_, err = b.writeAndRetry(syslog.LOG_WARNING, m)
+	case LOG_NOTICE:
+		_, err = b.writeAndRetry(syslog.LOG_NOTICE, m)
+	case LOG_INFO:
+		_, err = b.writeAndRetry(syslog.LOG_INFO, m)
+	case LOG_DEBUG:
+		_, err = b.writeAndRetry(syslog.LOG_DEBUG, m)
+	default:
+		err = fmt.Errorf("Unknown priority: %v", p)
+	}
+	return err
+}
+
+// facilityPriority converts a facility string into
+// an appropriate priority level or returns an error
+func facilityPriority(facility string) (syslog.Priority, error) {
+	facility = strings.ToUpper(facility)
+	switch facility {
+	case "KERN":
+		return syslog.LOG_KERN, nil
+	case "USER":
+		return syslog.LOG_USER, nil
+	case "MAIL":
+		return syslog.LOG_MAIL, nil
+	case "DAEMON":
+		return syslog.LOG_DAEMON, nil
+	case "AUTH":
+		return syslog.LOG_AUTH, nil
+	case "SYSLOG":
+		return syslog.LOG_SYSLOG, nil
+	case "LPR":
+		return syslog.LOG_LPR, nil
+	case "NEWS":
+		return syslog.LOG_NEWS, nil
+	case "UUCP":
+		return syslog.LOG_UUCP, nil
+	case "CRON":
+		return syslog.LOG_CRON, nil
+	case "AUTHPRIV":
+		return syslog.LOG_AUTHPRIV, nil
+	case "FTP":
+		return syslog.LOG_FTP, nil
+	case "LOCAL0":
+		return syslog.LOG_LOCAL0, nil
+	case "LOCAL1":
+		return syslog.LOG_LOCAL1, nil
+	case "LOCAL2":
+		return syslog.LOG_LOCAL2, nil
+	case "LOCAL3":
+		return syslog.LOG_LOCAL3, nil
+	case "LOCAL4":
+		return syslog.LOG_LOCAL4, nil
+	case "LOCAL5":
+		return syslog.LOG_LOCAL5, nil
+	case "LOCAL6":
+		return syslog.LOG_LOCAL6, nil
+	case "LOCAL7":
+		return syslog.LOG_LOCAL7, nil
+	default:
+		return 0, fmt.Errorf("invalid syslog facility: %s", facility)
+	}
+}

--- a/vendor/github.com/hashicorp/go-syslog/unsupported.go
+++ b/vendor/github.com/hashicorp/go-syslog/unsupported.go
@@ -1,0 +1,17 @@
+// +build windows plan9 nacl
+
+package gsyslog
+
+import (
+	"fmt"
+)
+
+// NewLogger is used to construct a new Syslogger
+func NewLogger(p Priority, facility, tag string) (Syslogger, error) {
+	return nil, fmt.Errorf("Platform does not support syslog")
+}
+
+// DialLogger is used to construct a new Syslogger that establishes connection to remote syslog server
+func DialLogger(network, raddr string, p Priority, facility, tag string) (Syslogger, error) {
+	return nil, fmt.Errorf("Platform does not support syslog")
+}

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -26,6 +26,14 @@
 			"notests": true
 		},
 		{
+			"importpath": "github.com/hashicorp/go-syslog",
+			"repository": "https://github.com/hashicorp/go-syslog",
+			"vcs": "git",
+			"revision": "326bf4a7f709d263f964a6a96558676b103f3534",
+			"branch": "master",
+			"notests": true
+		},
+		{
 			"importpath": "github.com/kavu/go_reuseport",
 			"repository": "https://github.com/kavu/go_reuseport",
 			"vcs": "git",
@@ -62,6 +70,14 @@
 			"repository": "https://github.com/rcrowley/go-metrics",
 			"vcs": "git",
 			"revision": "1f30fe9094a513ce4c700b9a54458bbb0c96996c",
+			"branch": "master",
+			"notests": true
+		},
+		{
+			"importpath": "github.com/spiffe/go-spiffe",
+			"repository": "https://github.com/spiffe/go-spiffe",
+			"vcs": "git",
+			"revision": "2bb3101d62b4bea6371d792e818360e3f056867b",
 			"branch": "master",
 			"notests": true
 		},
@@ -251,14 +267,6 @@
 			"revision": "1087e65c9441605df944fb12c33f0fe7072d18ca",
 			"branch": "master",
 			"notests": true
-		},
-        {
-            "importpath": "github.com/spiffe/go-spiffe",
-            "repository": "https://github.com/spiffe/go-spiffe",
-            "vcs": "git",
-            "revision": "2bb3101d62b4bea6371d792e818360e3f056867b",
-            "branch": "master",
-            "notests": true
-        }
+		}
 	]
 }


### PR DESCRIPTION
Changes to support Windows platforms:
* Use a wrapper package for `log/syslog` to fix import errors
* Update signal handling to work on Windows (signal-initiated reload not supported)

In action:
![virtualbox_msedge - win10_09_01_2018_18_16_35](https://user-images.githubusercontent.com/639883/34753040-a2bfa716-f56a-11e7-84e9-5a69ffa3f08c.png)

Tested 32-bit and 64-bit compile with PKCS11 disabled, and 32-bit compile with PKCS11 enabled (via MinGW/GCC). I have not tested an actual instance of Ghostunnel running with a PKCS11 module loaded on a Windows box, so no guarantees that that works right now. 