### PR TITLE
Flag cleanup

### DIFF
--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -27,9 +27,9 @@ WORKDIR /go/src/github.com/square/ghostunnel
 ENV GHOSTUNNEL_TEST_PKCS11=true
 
 # Set params for PKCS11 module
-ENV PKCS11_MODULE=/usr/lib/softhsm/libsofthsm2.so
-ENV PKCS11_LABEL=ghostunnel-pkcs11-test
-ENV PKCS11_PIN=1234
+ENV GHOSTUNNEL_TEST_PKCS11_MODULE=/usr/lib/softhsm/libsofthsm2.so
+ENV GHOSTUNNEL_TEST_PKCS11_LABEL=ghostunnel-pkcs11-test
+ENV GHOSTUNNEL_TEST_PKCS11_PIN=1234
 
 # Set SoftHSM config file
 ENV SOFTHSM2_CONF=/etc/softhsm/softhsm2.conf

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ $(INTEGRATION_TESTS): ghostunnel.test
 	@cd tests && ./runner.py $@
 
 softhsm-import:
-	softhsm2-util --init-token --slot 0 --label ${PKCS11_LABEL} --so-pin ${PKCS11_PIN} --pin ${PKCS11_PIN}
-	softhsm2-util --id 01 --token ${PKCS11_LABEL} --label ${PKCS11_LABEL} --import test-keys/server.pkcs8.key --so-pin ${PKCS11_PIN} --pin ${PKCS11_PIN}
+	softhsm2-util --init-token --slot 0 --label ${GHOSTUNNEL_TEST_PKCS11_LABEL} --so-pin ${GHOSTUNNEL_TEST_PKCS11_PIN} --pin ${GHOSTUNNEL_TEST_PKCS11_PIN}
+	softhsm2-util --id 01 --token ${GHOSTUNNEL_TEST_PKCS11_LABEL} --label ${GHOSTUNNEL_TEST_PKCS11_LABEL} --import test-keys/server.pkcs8.key --so-pin ${GHOSTUNNEL_TEST_PKCS11_PIN} --pin ${GHOSTUNNEL_TEST_PKCS11_PIN}
 
 docker-build:
 	docker build -t squareup/ghostunnel .
@@ -29,7 +29,7 @@ docker-test-build:
 	docker build --build-arg GO_VERSION=${GO_VERSION} -t squareup/ghostunnel-test -f Dockerfile-test .
 
 docker-test-run:
-	docker run -v /dev/log:/dev/log -v ${PWD}:/go/src/github.com/square/ghostunnel squareup/ghostunnel-test
+	docker run -v ${PWD}:/go/src/github.com/square/ghostunnel squareup/ghostunnel-test
 
 docker-test: docker-test-build docker-test-run
 

--- a/main_test.go
+++ b/main_test.go
@@ -81,10 +81,8 @@ func TestIntegrationMain(t *testing.T) {
 }
 
 func TestInitLoggerSyslog(t *testing.T) {
-	*useSyslog = true
-	defer func() { *useSyslog = false }()
 	originalLogger := logger
-	err := initLogger()
+	err := initLogger(true)
 	updatedLogger := logger
 	if err != nil {
 		// Tests running in containers often don't have access to syslog,

--- a/tests/test-server-pkcs11-module.py
+++ b/tests/test-server-pkcs11-module.py
@@ -17,9 +17,9 @@ if __name__ == "__main__":
     # hack: point target to STATUS_PORT so that /_status doesn't 503.
     ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
       '--target={0}:{1}'.format(LOCALHOST, STATUS_PORT), '--keystore=../test-keys/server.crt',
-      '--pkcs11-module={0}'.format(os.environ['PKCS11_MODULE']),
-      '--pkcs11-token-label={0}'.format(os.environ['PKCS11_LABEL']),
-      '--pkcs11-pin={0}'.format(os.environ['PKCS11_PIN']),
+      '--pkcs11-module={0}'.format(os.environ['GHOSTUNNEL_TEST_PKCS11_MODULE']),
+      '--pkcs11-token-label={0}'.format(os.environ['GHOSTUNNEL_TEST_PKCS11_LABEL']),
+      '--pkcs11-pin={0}'.format(os.environ['GHOSTUNNEL_TEST_PKCS11_PIN']),
       '--cacert=../test-keys/root.crt', '--allow-ou=client',
       '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
 

--- a/tls_cgo.go
+++ b/tls_cgo.go
@@ -25,9 +25,9 @@ import (
 )
 
 var (
-	pkcs11Module     = app.Flag("pkcs11-module", "Path to PKCS11 module (SO) file (optional)").PlaceHolder("PATH").ExistingFile()
-	pkcs11TokenLabel = app.Flag("pkcs11-token-label", "Token label for slot/key in PKCS11 module (optional)").PlaceHolder("LABEL").String()
-	pkcs11PIN        = app.Flag("pkcs11-pin", "PIN code for slot/key in PKCS11 module (optional)").PlaceHolder("PIN").String()
+	pkcs11Module     = app.Flag("pkcs11-module", "Path to PKCS11 module (SO) file (optional).").Envar("PKCS11_MODULE").PlaceHolder("PATH").ExistingFile()
+	pkcs11TokenLabel = app.Flag("pkcs11-token-label", "Token label for slot/key in PKCS11 module (optional).").Envar("PKCS11_TOKEN_LABEL").PlaceHolder("LABEL").String()
+	pkcs11PIN        = app.Flag("pkcs11-pin", "PIN code for slot/key in PKCS11 module (optional).").Envar("PKCS11_PIN").PlaceHolder("PIN").String()
 )
 
 func newPKCS11(pubkey crypto.PublicKey) (crypto.PrivateKey, error) {

--- a/unix.go
+++ b/unix.go
@@ -1,7 +1,7 @@
-// +build windows
+// +build !windows
 
 /*-
- * Copyright 2018 Square Inc.
+ * Copyright 2015 Square Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,9 +20,15 @@ package main
 
 import (
 	"os"
+	"syscall"
 )
 
 var (
-	shutdownSignals = []os.Signal{os.Interrupt}
-	refreshSignals  = []os.Signal{ /* Not supported on Windows */ }
+	shutdownSignals = []os.Signal{syscall.SIGINT, syscall.SIGTERM}
+	refreshSignals  = []os.Signal{syscall.SIGUSR1}
+	syslogFlag      = app.Flag("syslog", "Send logs to syslog instead of stderr.").Bool()
 )
+
+func useSyslog() bool {
+	return *syslogFlag
+}

--- a/windows.go
+++ b/windows.go
@@ -1,7 +1,7 @@
-// +build !windows
+// +build windows
 
 /*-
- * Copyright 2015 Square Inc.
+ * Copyright 2018 Square Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,10 +20,13 @@ package main
 
 import (
 	"os"
-	"syscall"
 )
 
 var (
-	shutdownSignals = []os.Signal{syscall.SIGINT, syscall.SIGTERM}
-	refreshSignals  = []os.Signal{syscall.SIGUSR1}
+	shutdownSignals = []os.Signal{os.Interrupt}
+	refreshSignals  = []os.Signal{ /* Not supported on Windows */ }
 )
+
+func useSyslog() bool {
+	return false
+}


### PR DESCRIPTION
* Skip syslog flag on Windows, since it's not supported.
* Add env vars for PKCS11 flags so PIN can be in env var if desired.