### PR TITLE
Only refer to flags in main, add extra tests for invalid flags

### DIFF
--- a/auth_test.go
+++ b/auth_test.go
@@ -54,191 +54,229 @@ func getURISANFromString(s string) (uriSAN []byte) {
 }
 
 func TestAuthorizeNotVerified(t *testing.T) {
-	*serverAllowAll = true
-	*serverAllowedCNs = []string{}
-	*serverAllowedOUs = []string{}
-	*serverAllowedDNSs = []string{}
-	*serverAllowedIPs = []net.IP{}
-	*serverAllowedURIs = []string{}
+	testACL := acl{
+		allowAll:    true,
+		allowedCNs:  []string{},
+		allowedOUs:  []string{},
+		allowedDNSs: []string{},
+		allowedIPs:  []net.IP{},
+		allowedURIs: []string{},
+	}
 
-	assert.NotNil(t, verifyPeerCertificateServer(nil, nil), "conn w/o cert should be rejected")
+	assert.NotNil(t, testACL.verifyPeerCertificateServer(nil, nil), "conn w/o cert should be rejected")
 }
 
 func TestAuthorizeReject(t *testing.T) {
-	*serverAllowAll = false
-	*serverAllowedCNs = []string{"test"}
-	*serverAllowedOUs = []string{"test"}
-	*serverAllowedDNSs = []string{"test"}
-	*serverAllowedIPs = []net.IP{}
-	*serverAllowedURIs = []string{"test"}
+	testACL := acl{
+		allowAll:    false,
+		allowedCNs:  []string{"test"},
+		allowedOUs:  []string{"test"},
+		allowedDNSs: []string{"test"},
+		allowedIPs:  []net.IP{},
+		allowedURIs: []string{"test"},
+	}
 
-	assert.NotNil(t, verifyPeerCertificateServer(nil, fakeChains), "should reject cert w/o matching CN/OU")
+	assert.NotNil(t, testACL.verifyPeerCertificateServer(nil, fakeChains), "should reject cert w/o matching CN/OU")
 }
 
 func TestAuthorizeAllowAll(t *testing.T) {
-	*serverAllowAll = true
-	*serverAllowedCNs = []string{}
-	*serverAllowedOUs = []string{}
-	*serverAllowedDNSs = []string{}
-	*serverAllowedIPs = []net.IP{}
+	testACL := acl{
+		allowAll:    true,
+		allowedCNs:  []string{},
+		allowedOUs:  []string{},
+		allowedDNSs: []string{},
+		allowedIPs:  []net.IP{},
+	}
 
-	assert.Nil(t, verifyPeerCertificateServer(nil, fakeChains), "allow-all should always allow authed clients")
+	assert.Nil(t, testACL.verifyPeerCertificateServer(nil, fakeChains), "allow-all should always allow authed clients")
 }
 
 func TestAuthorizeAllowCN(t *testing.T) {
-	*serverAllowAll = false
-	*serverAllowedCNs = []string{"gopher"}
-	*serverAllowedOUs = []string{}
-	*serverAllowedDNSs = []string{}
-	*serverAllowedIPs = []net.IP{}
-	*serverAllowedURIs = []string{}
+	testACL := acl{
+		allowAll:    false,
+		allowedCNs:  []string{"gopher"},
+		allowedOUs:  []string{},
+		allowedDNSs: []string{},
+		allowedIPs:  []net.IP{},
+		allowedURIs: []string{},
+	}
 
-	assert.Nil(t, verifyPeerCertificateServer(nil, fakeChains), "allow-cn should allow clients with matching CN")
+	assert.Nil(t, testACL.verifyPeerCertificateServer(nil, fakeChains), "allow-cn should allow clients with matching CN")
 }
 
 func TestAuthorizeAllowOU(t *testing.T) {
-	*serverAllowAll = false
-	*serverAllowedCNs = []string{}
-	*serverAllowedOUs = []string{"circle"}
-	*serverAllowedDNSs = []string{}
-	*serverAllowedIPs = []net.IP{}
-	*serverAllowedURIs = []string{}
+	testACL := acl{
+		allowAll:    false,
+		allowedCNs:  []string{},
+		allowedOUs:  []string{"circle"},
+		allowedDNSs: []string{},
+		allowedIPs:  []net.IP{},
+		allowedURIs: []string{},
+	}
 
-	assert.Nil(t, verifyPeerCertificateServer(nil, fakeChains), "allow-ou should allow clients with matching OU")
+	assert.Nil(t, testACL.verifyPeerCertificateServer(nil, fakeChains), "allow-ou should allow clients with matching OU")
 }
 
 func TestAuthorizeAllowDNS(t *testing.T) {
-	*serverAllowAll = false
-	*serverAllowedCNs = []string{}
-	*serverAllowedOUs = []string{}
-	*serverAllowedDNSs = []string{"circle"}
-	*serverAllowedIPs = []net.IP{}
-	*serverAllowedURIs = []string{}
+	testACL := acl{
+		allowAll:    false,
+		allowedCNs:  []string{},
+		allowedOUs:  []string{},
+		allowedDNSs: []string{"circle"},
+		allowedIPs:  []net.IP{},
+		allowedURIs: []string{},
+	}
 
-	assert.Nil(t, verifyPeerCertificateServer(nil, fakeChains), "allow-dns-san should allow clients with matching DNS SAN")
+	assert.Nil(t, testACL.verifyPeerCertificateServer(nil, fakeChains), "allow-dns-san should allow clients with matching DNS SAN")
 }
 
 func TestAuthorizeAllowIP(t *testing.T) {
-	*serverAllowAll = false
-	*serverAllowedCNs = []string{}
-	*serverAllowedOUs = []string{}
-	*serverAllowedDNSs = []string{}
-	*serverAllowedIPs = []net.IP{net.IPv4(192, 168, 99, 100)}
-	*serverAllowedURIs = []string{}
+	testACL := acl{
+		allowAll:    false,
+		allowedCNs:  []string{},
+		allowedOUs:  []string{},
+		allowedDNSs: []string{},
+		allowedIPs:  []net.IP{net.IPv4(192, 168, 99, 100)},
+		allowedURIs: []string{},
+	}
 
-	assert.Nil(t, verifyPeerCertificateServer(nil, fakeChains), "allow-ip-san should allow clients with matching IP SAN")
+	assert.Nil(t, testACL.verifyPeerCertificateServer(nil, fakeChains), "allow-ip-san should allow clients with matching IP SAN")
 }
 
 func TestAuthorizeAllowURI(t *testing.T) {
-	*serverAllowAll = false
-	*serverAllowedCNs = []string{}
-	*serverAllowedOUs = []string{}
-	*serverAllowedDNSs = []string{}
-	*serverAllowedIPs = []net.IP{}
-	*serverAllowedURIs = []string{"scheme://valid/path"}
+	testACL := acl{
+		allowAll:    false,
+		allowedCNs:  []string{},
+		allowedOUs:  []string{},
+		allowedDNSs: []string{},
+		allowedIPs:  []net.IP{},
+		allowedURIs: []string{"scheme://valid/path"},
+	}
 
-	assert.Nil(t, verifyPeerCertificateServer(nil, fakeChains), "allow-uri-san should allow clients with matching URI SAN")
+	assert.Nil(t, testACL.verifyPeerCertificateServer(nil, fakeChains), "allow-uri-san should allow clients with matching URI SAN")
 }
 
 func TestAuthorizeRejectURI(t *testing.T) {
-	*serverAllowAll = false
-	*serverAllowedCNs = []string{}
-	*serverAllowedOUs = []string{}
-	*serverAllowedDNSs = []string{}
-	*serverAllowedIPs = []net.IP{}
-	*serverAllowedURIs = []string{"schema://invalid/path"}
+	testACL := acl{
+		allowAll:    false,
+		allowedCNs:  []string{},
+		allowedOUs:  []string{},
+		allowedDNSs: []string{},
+		allowedIPs:  []net.IP{},
+		allowedURIs: []string{"schema://invalid/path"},
+	}
 
-	assert.NotNil(t, verifyPeerCertificateServer(nil, fakeChains), "should reject cert w/o matching URI")
+	assert.NotNil(t, testACL.verifyPeerCertificateServer(nil, fakeChains), "should reject cert w/o matching URI")
 }
 
 func TestVerifyAllowCN(t *testing.T) {
-	*clientAllowedCNs = []string{"gopher"}
-	*clientAllowedOUs = []string{}
-	*clientAllowedDNSs = []string{}
-	*clientAllowedIPs = []net.IP{}
+	testACL := acl{
+		allowedCNs:  []string{"gopher"},
+		allowedOUs:  []string{},
+		allowedDNSs: []string{},
+		allowedIPs:  []net.IP{},
+	}
 
-	assert.Nil(t, verifyPeerCertificateClient(nil, fakeChains), "verify-cn should allow servers with matching CN")
+	assert.Nil(t, testACL.verifyPeerCertificateClient(nil, fakeChains), "verify-cn should allow servers with matching CN")
 }
 
 func TestVerifyAllowOU(t *testing.T) {
-	*clientAllowedCNs = []string{}
-	*clientAllowedOUs = []string{"circle"}
-	*clientAllowedDNSs = []string{}
-	*clientAllowedIPs = []net.IP{}
+	testACL := acl{
+		allowedCNs:  []string{},
+		allowedOUs:  []string{"circle"},
+		allowedDNSs: []string{},
+		allowedIPs:  []net.IP{},
+	}
 
-	assert.Nil(t, verifyPeerCertificateClient(nil, fakeChains), "verify-ou should allow servers with matching OU")
+	assert.Nil(t, testACL.verifyPeerCertificateClient(nil, fakeChains), "verify-ou should allow servers with matching OU")
 }
 
 func TestVerifyAllowDNS(t *testing.T) {
-	*clientAllowedCNs = []string{}
-	*clientAllowedOUs = []string{}
-	*clientAllowedDNSs = []string{"circle"}
-	*clientAllowedIPs = []net.IP{}
+	testACL := acl{
+		allowedCNs:  []string{},
+		allowedOUs:  []string{},
+		allowedDNSs: []string{"circle"},
+		allowedIPs:  []net.IP{},
+	}
 
-	assert.Nil(t, verifyPeerCertificateClient(nil, fakeChains), "verify-dns-san should allow servers with matching DNS SAN")
+	assert.Nil(t, testACL.verifyPeerCertificateClient(nil, fakeChains), "verify-dns-san should allow servers with matching DNS SAN")
 }
 
 func TestVerifyAllowIP(t *testing.T) {
-	*clientAllowedCNs = []string{}
-	*clientAllowedOUs = []string{}
-	*clientAllowedDNSs = []string{}
-	*clientAllowedIPs = []net.IP{net.IPv4(192, 168, 99, 100)}
+	testACL := acl{
+		allowedCNs:  []string{},
+		allowedOUs:  []string{},
+		allowedDNSs: []string{},
+		allowedIPs:  []net.IP{net.IPv4(192, 168, 99, 100)},
+	}
 
-	assert.Nil(t, verifyPeerCertificateClient(nil, fakeChains), "verify-ip-san should allow servers with matching IP SAN")
+	assert.Nil(t, testACL.verifyPeerCertificateClient(nil, fakeChains), "verify-ip-san should allow servers with matching IP SAN")
 }
 
 func TestVerifyRejectCN(t *testing.T) {
-	*clientAllowedCNs = []string{"test"}
-	*clientAllowedOUs = []string{}
-	*clientAllowedDNSs = []string{}
-	*clientAllowedIPs = []net.IP{}
+	testACL := acl{
+		allowedCNs:  []string{"test"},
+		allowedOUs:  []string{},
+		allowedDNSs: []string{},
+		allowedIPs:  []net.IP{},
+	}
 
-	assert.NotNil(t, verifyPeerCertificateClient(nil, fakeChains), "should reject cert w/o matching CN")
+	assert.NotNil(t, testACL.verifyPeerCertificateClient(nil, fakeChains), "should reject cert w/o matching CN")
 }
 
 func TestVerifyRejectOU(t *testing.T) {
-	*clientAllowedCNs = []string{}
-	*clientAllowedOUs = []string{"test"}
-	*clientAllowedDNSs = []string{}
-	*clientAllowedIPs = []net.IP{}
+	testACL := acl{
+		allowedCNs:  []string{},
+		allowedOUs:  []string{"test"},
+		allowedDNSs: []string{},
+		allowedIPs:  []net.IP{},
+	}
 
-	assert.NotNil(t, verifyPeerCertificateClient(nil, fakeChains), "should reject cert w/o matching OU")
+	assert.NotNil(t, testACL.verifyPeerCertificateClient(nil, fakeChains), "should reject cert w/o matching OU")
 }
 
 func TestVerifyRejectDNS(t *testing.T) {
-	*clientAllowedCNs = []string{}
-	*clientAllowedOUs = []string{}
-	*clientAllowedDNSs = []string{"test"}
-	*clientAllowedIPs = []net.IP{}
+	testACL := acl{
+		allowedCNs:  []string{},
+		allowedOUs:  []string{},
+		allowedDNSs: []string{"test"},
+		allowedIPs:  []net.IP{},
+	}
 
-	assert.NotNil(t, verifyPeerCertificateClient(nil, fakeChains), "should reject cert w/o matching DNS SAN")
+	assert.NotNil(t, testACL.verifyPeerCertificateClient(nil, fakeChains), "should reject cert w/o matching DNS SAN")
 }
 
 func TestVerifyRejectIP(t *testing.T) {
-	*clientAllowedCNs = []string{}
-	*clientAllowedOUs = []string{}
-	*clientAllowedDNSs = []string{}
-	*clientAllowedIPs = []net.IP{net.IPv4(1, 1, 1, 1)}
+	testACL := acl{
+		allowedCNs:  []string{},
+		allowedOUs:  []string{},
+		allowedDNSs: []string{},
+		allowedIPs:  []net.IP{net.IPv4(1, 1, 1, 1)},
+	}
 
-	assert.NotNil(t, verifyPeerCertificateClient(nil, fakeChains), "should reject cert w/o matching IP SAN")
+	assert.NotNil(t, testACL.verifyPeerCertificateClient(nil, fakeChains), "should reject cert w/o matching IP SAN")
 }
 
 func TestVerifyAllowURI(t *testing.T) {
-	*clientAllowedCNs = []string{}
-	*clientAllowedOUs = []string{}
-	*clientAllowedDNSs = []string{}
-	*clientAllowedIPs = []net.IP{}
-	*clientAllowedURIs = []string{"scheme://valid/path"}
+	testACL := acl{
+		allowedCNs:  []string{},
+		allowedOUs:  []string{},
+		allowedDNSs: []string{},
+		allowedIPs:  []net.IP{},
+		allowedURIs: []string{"scheme://valid/path"},
+	}
 
-	assert.Nil(t, verifyPeerCertificateClient(nil, fakeChains), "verify-uri-san should allow clients with matching URI SAN")
+	assert.Nil(t, testACL.verifyPeerCertificateClient(nil, fakeChains), "verify-uri-san should allow clients with matching URI SAN")
 }
 
 func TestVerifyRejectURI(t *testing.T) {
-	*clientAllowedCNs = []string{}
-	*clientAllowedOUs = []string{}
-	*clientAllowedDNSs = []string{}
-	*clientAllowedIPs = []net.IP{}
-	*clientAllowedURIs = []string{"scheme://invalid/path"}
+	testACL := acl{
+		allowedCNs:  []string{},
+		allowedOUs:  []string{},
+		allowedDNSs: []string{},
+		allowedIPs:  []net.IP{},
+		allowedURIs: []string{"scheme://invalid/path"},
+	}
 
-	assert.NotNil(t, verifyPeerCertificateClient(nil, fakeChains), "should reject cert w/o matching URI")
+	assert.NotNil(t, testACL.verifyPeerCertificateClient(nil, fakeChains), "should reject cert w/o matching URI")
 }

--- a/auth_test.go
+++ b/auth_test.go
@@ -55,12 +55,7 @@ func getURISANFromString(s string) (uriSAN []byte) {
 
 func TestAuthorizeNotVerified(t *testing.T) {
 	testACL := acl{
-		allowAll:    true,
-		allowedCNs:  []string{},
-		allowedOUs:  []string{},
-		allowedDNSs: []string{},
-		allowedIPs:  []net.IP{},
-		allowedURIs: []string{},
+		allowAll: true,
 	}
 
 	assert.NotNil(t, testACL.verifyPeerCertificateServer(nil, nil), "conn w/o cert should be rejected")
@@ -68,11 +63,9 @@ func TestAuthorizeNotVerified(t *testing.T) {
 
 func TestAuthorizeReject(t *testing.T) {
 	testACL := acl{
-		allowAll:    false,
 		allowedCNs:  []string{"test"},
 		allowedOUs:  []string{"test"},
 		allowedDNSs: []string{"test"},
-		allowedIPs:  []net.IP{},
 		allowedURIs: []string{"test"},
 	}
 
@@ -81,11 +74,7 @@ func TestAuthorizeReject(t *testing.T) {
 
 func TestAuthorizeAllowAll(t *testing.T) {
 	testACL := acl{
-		allowAll:    true,
-		allowedCNs:  []string{},
-		allowedOUs:  []string{},
-		allowedDNSs: []string{},
-		allowedIPs:  []net.IP{},
+		allowAll: true,
 	}
 
 	assert.Nil(t, testACL.verifyPeerCertificateServer(nil, fakeChains), "allow-all should always allow authed clients")
@@ -93,12 +82,7 @@ func TestAuthorizeAllowAll(t *testing.T) {
 
 func TestAuthorizeAllowCN(t *testing.T) {
 	testACL := acl{
-		allowAll:    false,
-		allowedCNs:  []string{"gopher"},
-		allowedOUs:  []string{},
-		allowedDNSs: []string{},
-		allowedIPs:  []net.IP{},
-		allowedURIs: []string{},
+		allowedCNs: []string{"gopher"},
 	}
 
 	assert.Nil(t, testACL.verifyPeerCertificateServer(nil, fakeChains), "allow-cn should allow clients with matching CN")
@@ -106,12 +90,7 @@ func TestAuthorizeAllowCN(t *testing.T) {
 
 func TestAuthorizeAllowOU(t *testing.T) {
 	testACL := acl{
-		allowAll:    false,
-		allowedCNs:  []string{},
-		allowedOUs:  []string{"circle"},
-		allowedDNSs: []string{},
-		allowedIPs:  []net.IP{},
-		allowedURIs: []string{},
+		allowedOUs: []string{"circle"},
 	}
 
 	assert.Nil(t, testACL.verifyPeerCertificateServer(nil, fakeChains), "allow-ou should allow clients with matching OU")
@@ -119,12 +98,7 @@ func TestAuthorizeAllowOU(t *testing.T) {
 
 func TestAuthorizeAllowDNS(t *testing.T) {
 	testACL := acl{
-		allowAll:    false,
-		allowedCNs:  []string{},
-		allowedOUs:  []string{},
 		allowedDNSs: []string{"circle"},
-		allowedIPs:  []net.IP{},
-		allowedURIs: []string{},
 	}
 
 	assert.Nil(t, testACL.verifyPeerCertificateServer(nil, fakeChains), "allow-dns-san should allow clients with matching DNS SAN")
@@ -132,12 +106,7 @@ func TestAuthorizeAllowDNS(t *testing.T) {
 
 func TestAuthorizeAllowIP(t *testing.T) {
 	testACL := acl{
-		allowAll:    false,
-		allowedCNs:  []string{},
-		allowedOUs:  []string{},
-		allowedDNSs: []string{},
-		allowedIPs:  []net.IP{net.IPv4(192, 168, 99, 100)},
-		allowedURIs: []string{},
+		allowedIPs: []net.IP{net.IPv4(192, 168, 99, 100)},
 	}
 
 	assert.Nil(t, testACL.verifyPeerCertificateServer(nil, fakeChains), "allow-ip-san should allow clients with matching IP SAN")
@@ -145,11 +114,6 @@ func TestAuthorizeAllowIP(t *testing.T) {
 
 func TestAuthorizeAllowURI(t *testing.T) {
 	testACL := acl{
-		allowAll:    false,
-		allowedCNs:  []string{},
-		allowedOUs:  []string{},
-		allowedDNSs: []string{},
-		allowedIPs:  []net.IP{},
 		allowedURIs: []string{"scheme://valid/path"},
 	}
 
@@ -158,11 +122,6 @@ func TestAuthorizeAllowURI(t *testing.T) {
 
 func TestAuthorizeRejectURI(t *testing.T) {
 	testACL := acl{
-		allowAll:    false,
-		allowedCNs:  []string{},
-		allowedOUs:  []string{},
-		allowedDNSs: []string{},
-		allowedIPs:  []net.IP{},
 		allowedURIs: []string{"schema://invalid/path"},
 	}
 
@@ -171,10 +130,7 @@ func TestAuthorizeRejectURI(t *testing.T) {
 
 func TestVerifyAllowCN(t *testing.T) {
 	testACL := acl{
-		allowedCNs:  []string{"gopher"},
-		allowedOUs:  []string{},
-		allowedDNSs: []string{},
-		allowedIPs:  []net.IP{},
+		allowedCNs: []string{"gopher"},
 	}
 
 	assert.Nil(t, testACL.verifyPeerCertificateClient(nil, fakeChains), "verify-cn should allow servers with matching CN")
@@ -182,10 +138,7 @@ func TestVerifyAllowCN(t *testing.T) {
 
 func TestVerifyAllowOU(t *testing.T) {
 	testACL := acl{
-		allowedCNs:  []string{},
-		allowedOUs:  []string{"circle"},
-		allowedDNSs: []string{},
-		allowedIPs:  []net.IP{},
+		allowedOUs: []string{"circle"},
 	}
 
 	assert.Nil(t, testACL.verifyPeerCertificateClient(nil, fakeChains), "verify-ou should allow servers with matching OU")
@@ -193,10 +146,7 @@ func TestVerifyAllowOU(t *testing.T) {
 
 func TestVerifyAllowDNS(t *testing.T) {
 	testACL := acl{
-		allowedCNs:  []string{},
-		allowedOUs:  []string{},
 		allowedDNSs: []string{"circle"},
-		allowedIPs:  []net.IP{},
 	}
 
 	assert.Nil(t, testACL.verifyPeerCertificateClient(nil, fakeChains), "verify-dns-san should allow servers with matching DNS SAN")
@@ -204,10 +154,7 @@ func TestVerifyAllowDNS(t *testing.T) {
 
 func TestVerifyAllowIP(t *testing.T) {
 	testACL := acl{
-		allowedCNs:  []string{},
-		allowedOUs:  []string{},
-		allowedDNSs: []string{},
-		allowedIPs:  []net.IP{net.IPv4(192, 168, 99, 100)},
+		allowedIPs: []net.IP{net.IPv4(192, 168, 99, 100)},
 	}
 
 	assert.Nil(t, testACL.verifyPeerCertificateClient(nil, fakeChains), "verify-ip-san should allow servers with matching IP SAN")
@@ -215,10 +162,7 @@ func TestVerifyAllowIP(t *testing.T) {
 
 func TestVerifyRejectCN(t *testing.T) {
 	testACL := acl{
-		allowedCNs:  []string{"test"},
-		allowedOUs:  []string{},
-		allowedDNSs: []string{},
-		allowedIPs:  []net.IP{},
+		allowedCNs: []string{"test"},
 	}
 
 	assert.NotNil(t, testACL.verifyPeerCertificateClient(nil, fakeChains), "should reject cert w/o matching CN")
@@ -226,10 +170,7 @@ func TestVerifyRejectCN(t *testing.T) {
 
 func TestVerifyRejectOU(t *testing.T) {
 	testACL := acl{
-		allowedCNs:  []string{},
-		allowedOUs:  []string{"test"},
-		allowedDNSs: []string{},
-		allowedIPs:  []net.IP{},
+		allowedOUs: []string{"test"},
 	}
 
 	assert.NotNil(t, testACL.verifyPeerCertificateClient(nil, fakeChains), "should reject cert w/o matching OU")
@@ -237,10 +178,7 @@ func TestVerifyRejectOU(t *testing.T) {
 
 func TestVerifyRejectDNS(t *testing.T) {
 	testACL := acl{
-		allowedCNs:  []string{},
-		allowedOUs:  []string{},
 		allowedDNSs: []string{"test"},
-		allowedIPs:  []net.IP{},
 	}
 
 	assert.NotNil(t, testACL.verifyPeerCertificateClient(nil, fakeChains), "should reject cert w/o matching DNS SAN")
@@ -248,10 +186,7 @@ func TestVerifyRejectDNS(t *testing.T) {
 
 func TestVerifyRejectIP(t *testing.T) {
 	testACL := acl{
-		allowedCNs:  []string{},
-		allowedOUs:  []string{},
-		allowedDNSs: []string{},
-		allowedIPs:  []net.IP{net.IPv4(1, 1, 1, 1)},
+		allowedIPs: []net.IP{net.IPv4(1, 1, 1, 1)},
 	}
 
 	assert.NotNil(t, testACL.verifyPeerCertificateClient(nil, fakeChains), "should reject cert w/o matching IP SAN")
@@ -259,10 +194,6 @@ func TestVerifyRejectIP(t *testing.T) {
 
 func TestVerifyAllowURI(t *testing.T) {
 	testACL := acl{
-		allowedCNs:  []string{},
-		allowedOUs:  []string{},
-		allowedDNSs: []string{},
-		allowedIPs:  []net.IP{},
 		allowedURIs: []string{"scheme://valid/path"},
 	}
 
@@ -271,12 +202,14 @@ func TestVerifyAllowURI(t *testing.T) {
 
 func TestVerifyRejectURI(t *testing.T) {
 	testACL := acl{
-		allowedCNs:  []string{},
-		allowedOUs:  []string{},
-		allowedDNSs: []string{},
-		allowedIPs:  []net.IP{},
 		allowedURIs: []string{"scheme://invalid/path"},
 	}
 
 	assert.NotNil(t, testACL.verifyPeerCertificateClient(nil, fakeChains), "should reject cert w/o matching URI")
+}
+
+func TestVerifyNoVerifiedChains(t *testing.T) {
+	testACL := acl{}
+
+	assert.NotNil(t, testACL.verifyPeerCertificateClient(nil, nil), "should reject if no verified chains")
 }

--- a/main.go
+++ b/main.go
@@ -334,8 +334,17 @@ func serverListen(context *Context) error {
 		return err
 	}
 
+	serverACL := acl{
+		allowAll:    *serverAllowAll,
+		allowedCNs:  *serverAllowedCNs,
+		allowedOUs:  *serverAllowedOUs,
+		allowedDNSs: *serverAllowedDNSs,
+		allowedIPs:  *serverAllowedIPs,
+		allowedURIs: *serverAllowedURIs,
+	}
+
 	config.GetCertificate = context.cert.getCertificate
-	config.VerifyPeerCertificate = verifyPeerCertificateServer
+	config.VerifyPeerCertificate = serverACL.verifyPeerCertificateServer
 
 	listener, err := reuseport.NewReusablePortListener("tcp", (*serverListenAddress).String())
 	if err != nil {
@@ -497,7 +506,15 @@ func clientBackendDialer(cert *certificate, network, address, host string) (func
 		config.ServerName = *clientServerName
 	}
 
-	config.VerifyPeerCertificate = verifyPeerCertificateClient
+	clientACL := acl{
+		allowedCNs:  *clientAllowedCNs,
+		allowedOUs:  *clientAllowedOUs,
+		allowedDNSs: *clientAllowedDNSs,
+		allowedIPs:  *clientAllowedIPs,
+		allowedURIs: *clientAllowedURIs,
+	}
+
+	config.VerifyPeerCertificate = clientACL.verifyPeerCertificateClient
 
 	var dialer Dialer = &net.Dialer{Timeout: *timeoutDuration}
 

--- a/main_test.go
+++ b/main_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net"
+	"net/url"
 	"os"
 	"sync"
 	"testing"
@@ -125,6 +126,7 @@ func TestServerFlagValidation(t *testing.T) {
 	*serverAllowedOUs = nil
 	*serverAllowedDNSs = nil
 	*serverAllowedIPs = nil
+	*serverAllowedURIs = nil
 	err := serverValidateFlags()
 	assert.NotNil(t, err, "invalid access control flags accepted")
 
@@ -170,6 +172,12 @@ func TestClientFlagValidation(t *testing.T) {
 	*clientListenAddress = "127.0.0.1:8080"
 	err = clientValidateFlags()
 	assert.NotNil(t, err, "invalid cipher suite option should be rejected")
+
+	invalidURL, _ := url.Parse("ftp://invalid")
+	*enabledCipherSuites = "AES"
+	*clientConnectProxy = invalidURL
+	err = clientValidateFlags()
+	assert.NotNil(t, err, "invalid connect proxy option should be rejected")
 }
 
 func TestAllowsLocalhost(t *testing.T) {

--- a/signals.go
+++ b/signals.go
@@ -58,7 +58,7 @@ func (context *Context) signalHandler(proxy *proxy, closeables []io.Closer) {
 				}
 
 				// Force-exit after timeout
-				time.AfterFunc(*shutdownTimeout, func() {
+				time.AfterFunc(context.shutdownTimeout, func() {
 					// Graceful shutdown timeout reached. If we can't drain connections
 					// to exit gracefully after this timeout, let's just exit.
 					logger.Printf("graceful shutdown timeout: forcing exit")

--- a/tests/test-invalid-cacert.py
+++ b/tests/test-invalid-cacert.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+from subprocess import Popen
+from common import *
+import socket, ssl, time, os, signal
+
+if __name__ == "__main__":
+  ghostunnel = None
+  try:
+    # create certs
+    root = RootCert('root')
+    root.create_signed_cert('client')
+
+    # start ghostunnel with bad cert
+    ghostunnel = run_ghostunnel(['client', '--listen={0}:13001'.format(LOCALHOST),
+      '--target={0}:13002'.format(LOCALHOST), '--keystore=client.p12',
+      '--cacert=root.key', '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
+
+    # wait for ghostunnel to exit and make sure error code is not zero
+    ret = ghostunnel.wait(timeout=20)
+    if ret == 0:
+      raise Exception('ghostunnel terminated with zero, though cacert was invalid')  
+    else:
+      print_ok("OK (terminated)")
+  finally:
+    terminate(ghostunnel)

--- a/tests/test-invalid-certificate.py
+++ b/tests/test-invalid-certificate.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+from subprocess import Popen
+from common import *
+import socket, ssl, time, os, signal
+
+if __name__ == "__main__":
+  ghostunnel = None
+  try:
+    # create certs
+    root = RootCert('root')
+    root.create_signed_cert('client')
+
+    # start ghostunnel with bad cert
+    ghostunnel = run_ghostunnel(['client', '--listen={0}:13001'.format(LOCALHOST),
+      '--target={0}:13002'.format(LOCALHOST), '--keystore=client.key',
+      '--cacert=root.crt', '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
+
+    # wait for ghostunnel to exit and make sure error code is not zero
+    ret = ghostunnel.wait(timeout=20)
+    if ret == 0:
+      raise Exception('ghostunnel terminated with zero, though cert was invalid')  
+    else:
+      print_ok("OK (terminated)")
+  finally:
+    terminate(ghostunnel)

--- a/tests/test-invalid-client-flags.py
+++ b/tests/test-invalid-client-flags.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+from subprocess import Popen
+from common import *
+import socket, ssl, time, os, signal
+
+if __name__ == "__main__":
+  ghostunnel = None
+  try:
+    # create certs
+    root = RootCert('root')
+    root.create_signed_cert('server')
+
+    # start ghostunnel with bad flags
+    ghostunnel = run_ghostunnel(['client', '--listen={0}:13001'.format(LOCALHOST),
+      '--target={0}:13002'.format(LOCALHOST), '--keystore=server.p12',
+      '--connect-proxy=ftp://invalid', '--cacert=root.crt',
+      '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
+
+    # wait for ghostunnel to exit and make sure error code is not zero
+    ret = ghostunnel.wait(timeout=20)
+    if ret == 0:
+      raise Exception('ghostunnel terminated with zero, though flags were invalid')  
+    else:
+      print_ok("OK (terminated)")
+  finally:
+    terminate(ghostunnel)

--- a/tests/test-invalid-server-flags.py
+++ b/tests/test-invalid-server-flags.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+from subprocess import Popen
+from common import *
+import socket, ssl, time, os, signal
+
+if __name__ == "__main__":
+  ghostunnel = None
+  try:
+    # create certs
+    root = RootCert('root')
+    root.create_signed_cert('server')
+
+    # start ghostunnel with bad flags
+    ghostunnel = run_ghostunnel(['server', '--listen={0}:13001'.format(LOCALHOST),
+      '--target={0}:13002'.format(LOCALHOST), '--keystore=server.p12',
+      '--cacert=root.crt', '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)])
+
+    # wait for ghostunnel to exit and make sure error code is not zero
+    ret = ghostunnel.wait(timeout=20)
+    if ret == 0:
+      raise Exception('ghostunnel terminated with zero, though flags were invalid')  
+    else:
+      print_ok("OK (terminated)")
+  finally:
+    terminate(ghostunnel)

--- a/tls.go
+++ b/tls.go
@@ -225,7 +225,7 @@ func dialWithDialer(dialer Dialer, timeout time.Duration, network, addr string, 
 }
 
 // buildConfig reads command-line options and builds a tls.Config
-func buildConfig(caBundlePath string) (*tls.Config, error) {
+func buildConfig(enabledCipherSuites string, caBundlePath string) (*tls.Config, error) {
 	ca, err := caBundle(caBundlePath)
 	if err != nil {
 		return nil, err
@@ -236,7 +236,7 @@ func buildConfig(caBundlePath string) (*tls.Config, error) {
 	// * We list AES-128 ahead of AES-256 for performance reasons.
 
 	suites := []uint16{}
-	for _, suite := range strings.Split(*enabledCipherSuites, ",") {
+	for _, suite := range strings.Split(enabledCipherSuites, ",") {
 		ciphers, ok := cipherSuites[strings.TrimSpace(suite)]
 		if !ok {
 			return nil, fmt.Errorf("invalid cipher suite '%s' selected", suite)

--- a/tls_test.go
+++ b/tls_test.go
@@ -180,18 +180,16 @@ func TestBuildConfig(t *testing.T) {
 	defer os.Remove(tmpCaBundle.Name())
 	defer os.Remove(tmpKeystoreNoPrivKey.Name())
 
-	*enabledCipherSuites = ""
-	conf, err := buildConfig(tmpCaBundle.Name())
+	conf, err := buildConfig("", tmpCaBundle.Name())
 	assert.NotNil(t, err, "should fail to build config with no cipher suites")
 
-	*enabledCipherSuites = "AES,CHACHA"
-	conf, err = buildConfig(tmpCaBundle.Name())
+	conf, err = buildConfig("AES,CHACHA", tmpCaBundle.Name())
 	assert.Nil(t, err, "should be able to build TLS config")
 	assert.NotNil(t, conf.RootCAs, "config must have CA certs")
 	assert.NotNil(t, conf.ClientCAs, "config must have CA certs")
 	assert.True(t, conf.MinVersion == tls.VersionTLS12, "must have correct TLS min version")
 
-	conf, err = buildConfig("does-not-exist")
+	conf, err = buildConfig("AES", "does-not-exist")
 	assert.Nil(t, conf, "conf with invalid params should be nil")
 	assert.NotNil(t, err, "should reject invalid CA cert bundle")
 
@@ -222,21 +220,17 @@ func TestCipherSuitePreference(t *testing.T) {
 	tmpCaBundle.Sync()
 	defer os.Remove(tmpCaBundle.Name())
 
-	*enabledCipherSuites = "XYZ"
-	conf, err := buildConfig(tmpCaBundle.Name())
+	conf, err := buildConfig("XYZ", tmpCaBundle.Name())
 	assert.NotNil(t, err, "should not be able to build TLS config with invalid cipher suite option")
 
-	*enabledCipherSuites = ""
-	conf, err = buildConfig(tmpCaBundle.Name())
+	conf, err = buildConfig("", tmpCaBundle.Name())
 	assert.NotNil(t, err, "should not be able to build TLS config wihout cipher suite selection")
 
-	*enabledCipherSuites = "CHACHA,AES"
-	conf, err = buildConfig(tmpCaBundle.Name())
+	conf, err = buildConfig("CHACHA,AES", tmpCaBundle.Name())
 	assert.Nil(t, err, "should be able to build TLS config")
 	assert.True(t, conf.CipherSuites[0] == tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305, "expecting ChaCha20")
 
-	*enabledCipherSuites = "AES,CHACHA"
-	conf, err = buildConfig(tmpCaBundle.Name())
+	conf, err = buildConfig("AES,CHACHA", tmpCaBundle.Name())
 	assert.Nil(t, err, "should be able to build TLS config")
 	assert.True(t, conf.CipherSuites[0] == tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, "expecting AES")
 }
@@ -262,7 +256,7 @@ func TestBuildConfigSystemRoots(t *testing.T) {
 		t.SkipNow()
 		return
 	}
-	conf, err := buildConfig("")
+	conf, err := buildConfig("AES", "")
 	assert.Nil(t, err, "should be able to build TLS config")
 	assert.NotNil(t, conf.RootCAs, "config must have CA certs")
 	assert.NotNil(t, conf.ClientCAs, "config must have CA certs")


### PR DESCRIPTION
Changes to make only main read flags directly, otherwise have them passed as arguments. Add some extra test cases related to flag handling. 