### PR TITLE
add a Makefile.dist for compiling releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ ghostunnel
 ghostunnel.exe
 ghostunnel.test
 __pycache__
+/pkg

--- a/Makefile.dist
+++ b/Makefile.dist
@@ -1,0 +1,131 @@
+# Metadata about this makefile and position
+MKFILE_PATH := $(lastword $(MAKEFILE_LIST))
+CURRENT_DIR := $(patsubst %/,%,$(dir $(realpath $(MKFILE_PATH))))
+
+GOVERSION := 1.10.0
+
+# Current system information
+GOOS ?= $(shell go env GOOS)
+GOARCH ?= $(shell go env GOARCH)
+
+# Default os-arch combination to build
+XC_OS ?= darwin freebsd linux netbsd openbsd solaris windows
+XC_ARCH ?= 386 amd64
+XC_EXCLUDE ?= solaris/386 solaris/amd64
+
+PROJECT := $(CURRENT_DIR:$(GOPATH)/src/%=%)
+NAME := $(notdir $(PROJECT))
+GIT_COMMIT ?= $(shell git rev-parse --short HEAD)
+VERSION := $(shell awk -F\" '/version/ { print $$2; exit }' "${CURRENT_DIR}/main.go")
+
+LD_FLAGS ?= \
+	-s \
+	-w -extldflags "-static" -extld x86_64-w64-mingw32-gcc \
+	-X ${PROJECT}/version.Name=${NAME} \
+	-X ${PROJECT}/version.GitCommit=${GIT_COMMIT}
+
+clean:
+	rm -rf *.out */*.out ghostunnel.test tests/__pycache__
+
+# bootstrap installs the necessary go tools for development or build.
+bootstrap:
+	@echo "==> Bootstrapping ${PROJECT}"
+	@for t in ${EXTERNAL_TOOLS}; do \
+		echo "--> Installing $$t" ; \
+		go get -u "$$t"; \
+	done
+.PHONY: bootstrap
+
+# Create a cross-compile target for every os-arch pairing. This will generate
+# a make target for each os/arch like "make linux/amd64" as well as generate a
+# meta target (build) for compiling everything.
+define make-xc-target
+  $1/$2:
+  ifneq (,$(findstring ${1}/${2},$(XC_EXCLUDE)))
+	@printf "%s%20s %s\n" "-->" "${1}/${2}:" "${PROJECT} (excluded)"
+  else ifeq (${1},windows)
+	@printf "%s%20s %s\n" "-->" "${1}/${2}:" "${PROJECT} (-w -extldflags "-static" -extld x86_64-w64-mingw32-gcc}"
+	@docker run \
+	        --interactive \
+	        --rm \
+	        --dns="8.8.8.8" \
+	        --volume="${CURRENT_DIR}:/go/src/${PROJECT}" \
+	        --workdir="/go/src/${PROJECT}" \
+	        "golang:${GOVERSION}" \
+	        env \
+	                CGO_ENABLED="0" \
+	                GOOS="${1}" \
+	                GOARCH="${2}" \
+	                go build \
+	                  -a \
+	                        -o="pkg/${1}_${2}/${NAME}${3}" \
+	                        -ldflags "${LD_FLAGS} -w -extldflags "-static" -extld x86_64-w64-mingw32-gcc" \
+	                        -tags "${GOTAGS}"
+  else
+	@printf "%s%20s %s\n" "-->" "${1}/${2}:" "${PROJECT}"
+	@docker run \
+		--interactive \
+		--rm \
+		--dns="8.8.8.8" \
+		--volume="${CURRENT_DIR}:/go/src/${PROJECT}" \
+		--workdir="/go/src/${PROJECT}" \
+		"golang:${GOVERSION}" \
+		env \
+			CGO_ENABLED="0" \
+			GOOS="${1}" \
+			GOARCH="${2}" \
+			go build \
+			  -a \
+				-o="pkg/${1}_${2}/${NAME}${3}" \
+				-ldflags "${LD_FLAGS}" \
+				-tags "${GOTAGS}"
+  endif
+  .PHONY: $1/$2
+
+  $1:: $1/$2
+  .PHONY: $1
+
+  build:: $1/$2
+  .PHONY: build
+endef
+$(foreach goarch,$(XC_ARCH),$(foreach goos,$(XC_OS),$(eval $(call make-xc-target,$(goos),$(goarch),$(if $(findstring windows,$(goos)),.exe,)))))
+
+# dist builds the binaries and then signs and packages them for distribution
+dist:
+	@$(MAKE) -f "${MKFILE_PATH}" _cleanup
+	@$(MAKE) -f "${MKFILE_PATH}" -j4 build
+	@$(MAKE) -f "${MKFILE_PATH}" _compress _checksum
+.PHONY: dist
+
+# _compress compresses all the binaries in pkg/* as tarball and zip.
+_compress:
+	@mkdir -p "${CURRENT_DIR}/pkg/dist"
+	@for platform in $$(find ./pkg -mindepth 1 -maxdepth 1 -type d); do \
+		osarch=$$(basename "$$platform"); \
+		if [ "$$osarch" = "dist" ]; then \
+			continue; \
+		fi; \
+		\
+		ext=""; \
+		if test -z "$${osarch##*windows*}"; then \
+			ext=".exe"; \
+		fi; \
+		cd "$$platform"; \
+		tar -czf "${CURRENT_DIR}/pkg/dist/${NAME}_${VERSION}_$${osarch}.tgz" "${NAME}$${ext}"; \
+		zip -q "${CURRENT_DIR}/pkg/dist/${NAME}_${VERSION}_$${osarch}.zip" "${NAME}$${ext}"; \
+		cd - &>/dev/null; \
+	done
+.PHONY: _compress
+
+# _checksum produces the checksums for the binaries in pkg/dist
+_checksum:
+	@cd "${CURRENT_DIR}/pkg/dist" && \
+		shasum --algorithm 256 * > ${CURRENT_DIR}/pkg/dist/${NAME}_${VERSION}_SHA256SUMS && \
+		cd - &>/dev/null
+.PHONY: _checksum
+
+# _cleanup removes any previous binaries
+_cleanup:
+	@rm -rf "${CURRENT_DIR}/pkg/"
+	@rm -rf "${CURRENT_DIR}/bin/"
+.PHONY: _cleanup


### PR DESCRIPTION
my stab at #152 

clean run:

```shell
ghostunnel ewdurbin$ git clean -fxd
Removing pkg/
ghostunnel ewdurbin$ make -f Makefile.dist dist
-->         darwin/386: github.com/square/ghostunnel
-->        freebsd/386: github.com/square/ghostunnel
-->          linux/386: github.com/square/ghostunnel
-->         netbsd/386: github.com/square/ghostunnel
-->        openbsd/386: github.com/square/ghostunnel
-->        solaris/386: github.com/square/ghostunnel (excluded)
-->        windows/386: github.com/square/ghostunnel (-w -extldflags -static -extld x86_64-w64-mingw32-gcc}
-->       darwin/amd64: github.com/square/ghostunnel
-->      freebsd/amd64: github.com/square/ghostunnel
-->        linux/amd64: github.com/square/ghostunnel
-->       netbsd/amd64: github.com/square/ghostunnel
-->      openbsd/amd64: github.com/square/ghostunnel
-->      solaris/amd64: github.com/square/ghostunnel (excluded)
-->      windows/amd64: github.com/square/ghostunnel (-w -extldflags -static -extld x86_64-w64-mingw32-gcc}
ghostunnel ewdurbin$ tree pkg/
pkg/
├── darwin_386
│   └── ghostunnel
├── darwin_amd64
│   └── ghostunnel
├── dist
│   ├── ghostunnel_v1.2.0-rc.1_SHA256SUMS
│   ├── ghostunnel_v1.2.0-rc.1_darwin_386.tgz
│   ├── ghostunnel_v1.2.0-rc.1_darwin_386.zip
│   ├── ghostunnel_v1.2.0-rc.1_darwin_amd64.tgz
│   ├── ghostunnel_v1.2.0-rc.1_darwin_amd64.zip
│   ├── ghostunnel_v1.2.0-rc.1_freebsd_386.tgz
│   ├── ghostunnel_v1.2.0-rc.1_freebsd_386.zip
│   ├── ghostunnel_v1.2.0-rc.1_freebsd_amd64.tgz
│   ├── ghostunnel_v1.2.0-rc.1_freebsd_amd64.zip
│   ├── ghostunnel_v1.2.0-rc.1_linux_386.tgz
│   ├── ghostunnel_v1.2.0-rc.1_linux_386.zip
│   ├── ghostunnel_v1.2.0-rc.1_linux_amd64.tgz
│   ├── ghostunnel_v1.2.0-rc.1_linux_amd64.zip
│   ├── ghostunnel_v1.2.0-rc.1_netbsd_386.tgz
│   ├── ghostunnel_v1.2.0-rc.1_netbsd_386.zip
│   ├── ghostunnel_v1.2.0-rc.1_netbsd_amd64.tgz
│   ├── ghostunnel_v1.2.0-rc.1_netbsd_amd64.zip
│   ├── ghostunnel_v1.2.0-rc.1_openbsd_386.tgz
│   ├── ghostunnel_v1.2.0-rc.1_openbsd_386.zip
│   ├── ghostunnel_v1.2.0-rc.1_openbsd_amd64.tgz
│   ├── ghostunnel_v1.2.0-rc.1_openbsd_amd64.zip
│   ├── ghostunnel_v1.2.0-rc.1_windows_386.tgz
│   ├── ghostunnel_v1.2.0-rc.1_windows_386.zip
│   ├── ghostunnel_v1.2.0-rc.1_windows_amd64.tgz
│   └── ghostunnel_v1.2.0-rc.1_windows_amd64.zip
├── freebsd_386
│   └── ghostunnel
├── freebsd_amd64
│   └── ghostunnel
├── linux_386
│   └── ghostunnel
├── linux_amd64
│   └── ghostunnel
├── netbsd_386
│   └── ghostunnel
├── netbsd_amd64
│   └── ghostunnel
├── openbsd_386
│   └── ghostunnel
├── openbsd_amd64
│   └── ghostunnel
├── windows_386
│   └── ghostunnel.exe
└── windows_amd64
    └── ghostunnel.exe

13 directories, 37 files
```

**Note**: skipping arm just cause.
**Note**: skipping solaris as it didn't like SO_REUSEPORT
**Note**: *NO IDEA* if the windows binaries work as anticipated with PKCS#11... though I did try a basic test they seemed to be alright for "regular" use.

<img width="1062" alt="screen shot 2018-03-04 at 4 20 30 pm" src="https://user-images.githubusercontent.com/1200832/36950977-c1589198-1fcb-11e8-8f46-6d8d3d26db2f.png">