### PR TITLE
Add Makefile.dist for release binaries in Travis-CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,6 @@
 ghostunnel
 ghostunnel.exe
 ghostunnel.test
+ghostunnel-*
 __pycache__
-/pkg
+dist/

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ ghostunnel
 ghostunnel.exe
 ghostunnel.test
 __pycache__
+/pkg

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ dist: trusty
 services:
   - docker
 
-env:
-  - LIBTOOL_PATH=https://ftp.gnu.org/pub/gnu/libtool/libtool-2.4.6.tar.gz
-
 go:
   - '1.10.x'
 
@@ -19,16 +16,18 @@ deploy:
     api_key:
       secure: 'rxcM8Ttmo0zTd2i+NBgG6YIDwtRwNCL28vPvAQ4GZ/SS7+8/fZn1RF8ZI2wWbZB2SqQveAiPmO66ZPXcGDsf/ynOHVvppn7IwJRSJoh2Z+QNu5i97JqQEtcM3DY5DZKO+scYqeCvINmLXmwSLHYDij/Nnu0hBXeobPizBDhqnN7AD0FZq2zbbCxZFPrAwUsB1G6wZTKWRFl4lX7baKDqyICc6OgGzb3m127SgrseW2zR6vBfHbc3Ep1hoIqjTf0vVXyDhCpDaIXAkZP43Jp1FxBwryrhEtPzx/46KWvPJLRwZc5gnRRrXX0HqrhlD577OxE/8VnjI+32mRTTNjSD8aOBraZ1Q71U5uLXLMoL1LD3qAfYv5sJaUKdbGtDkfGGwQ4X70A97gqmQI5gpYWU1LUksHwVJMwUqO2cPWciQikOTXQrDUT3qnuauZ432IP7izNhYmFWYwOEoQOzUA8pF1dl2jvUURY9dgQ2AHcJfCYV9C5TnBQ/2nO4Xbc96eo/Ky5OIX+lsfHx4bJmqvT6N+o/b9TJQYg3o4t0rqGB95Zt8/SbapvKlIU5I8SKGyuEpnKN4yUGAQRg8heuAPJ8mz3bmGriT9oC3q577vAqaCm2JcmvHCVx9OME0B04vLzxjYJXPHAi9CRmhUOZ8haHby3BkI3KYjnAaasUBot7oPI='
     file:
-      - ghostunnel-${TRAVIS_TAG}-linux-amd64-with-pkcs11
-      - ghostunnel-${TRAVIS_TAG}-darwin-amd64-with-pkcs11
-      - ghostunnel-${TRAVIS_TAG}-windows-amd64-with-pkcs11.exe
-      - ghostunnel-${TRAVIS_TAG}-windows-386-with-pkcs11.exe
-      - ghostunnel-${TRAVIS_TAG}-freebsd-amd64-without-pkcs11
-      - ghostunnel-${TRAVIS_TAG}-linux-amd64-with-pkcs11.sha256sum
-      - ghostunnel-${TRAVIS_TAG}-darwin-amd64-with-pkcs11.sha256sum
-      - ghostunnel-${TRAVIS_TAG}-windows-amd64-with-pkcs11.exe.sha256sum
-      - ghostunnel-${TRAVIS_TAG}-windows-386-with-pkcs11.exe.sha256sum
-      - ghostunnel-${TRAVIS_TAG}-freebsd-amd64-without-pkcs11.sha256sum
+      - dist/ghostunnel-${TRAVIS_TAG}-linux-386
+      - dist/ghostunnel-${TRAVIS_TAG}-linux-amd64
+      - dist/ghostunnel-${TRAVIS_TAG}-darwin-386
+      - dist/ghostunnel-${TRAVIS_TAG}-darwin-amd64
+      - dist/ghostunnel-${TRAVIS_TAG}-freebsd-386
+      - dist/ghostunnel-${TRAVIS_TAG}-freebsd-amd64
+      - dist/ghostunnel-${TRAVIS_TAG}-netbsd-386
+      - dist/ghostunnel-${TRAVIS_TAG}-netbsd-amd64
+      - dist/ghostunnel-${TRAVIS_TAG}-openbsd-386
+      - dist/ghostunnel-${TRAVIS_TAG}-openbsd-amd64
+      - dist/ghostunnel-${TRAVIS_TAG}-windows-386.exe
+      - dist/ghostunnel-${TRAVIS_TAG}-windows-amd64.exe
     draft: true
     skip_cleanup: true
     on:
@@ -38,28 +37,18 @@ before_install:
   - sudo apt-get update
   - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
   - go get github.com/mattn/goveralls
-  - go get github.com/karalabe/xgo
 
 install:
-  # Compile with CGO on/off for Linux
+  # Compile with CGO on/off for testing
   - CGO_ENABLED=0 go build -o ghostunnel-${TRAVIS_TAG}-linux-amd64-without-pkcs11 .
   - CGO_ENABLED=1 go build -o ghostunnel-${TRAVIS_TAG}-linux-amd64-with-pkcs11 .
-  # Cross-compile with CGO disabled
-  - CGO_ENABLED=0 GOOS=freebsd GOARCH=amd64 go build -o ghostunnel-${TRAVIS_TAG}-freebsd-amd64-without-pkcs11 .
-  # Cross-compile with CGO enabled
-  - xgo -go ${TRAVIS_GO_VERSION} -deps ${LIBTOOL_PATH} -targets 'windows-5.1/amd64' -ldflags '-w -extldflags "-static" -extld x86_64-w64-mingw32-gcc' .
-  - mv ghostunnel-windows-*-amd64.exe ghostunnel-${TRAVIS_TAG}-windows-amd64-with-pkcs11.exe
-  - xgo -go ${TRAVIS_GO_VERSION} -deps ${LIBTOOL_PATH} -targets 'windows-5.1/386' -ldflags '-w -extldflags "-static" -extld i686-w64-mingw32-gcc' .
-  - mv ghostunnel-windows-*-386.exe ghostunnel-${TRAVIS_TAG}-windows-386-with-pkcs11.exe
-  - xgo -go ${TRAVIS_GO_VERSION} -deps ${LIBTOOL_PATH} -targets 'darwin/amd64' .
-  - mv ghostunnel-darwin-*-amd64 ghostunnel-${TRAVIS_TAG}-darwin-amd64-with-pkcs11
-  # Generate checksums for GitHub release binaries
-  - 'for file in ghostunnel-${TRAVIS_TAG}-*; do sha256sum ${file} > ${file}.sha256sum; done'
   # Build Docker container
   - make docker-build
+  # Cross-compile dist binaries
+  - GO_VERSION=${TRAVIS_GO_VERSION} VERSION=${TRAVIS_TAG} make -f Makefile.dist dist
 
 script:
-  # Run tests inside Docker, guarantees that we have proper PKCS11 test setup
+  # Run tests inside Docker (guarantees that we have proper PKCS11 test setup)
   - GO_VERSION=${TRAVIS_GO_VERSION} make docker-test
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ before_install:
   - sudo apt-get update
   - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
   - go get github.com/mattn/goveralls
+  - go get github.com/karalabe/xgo
 
 install:
   # Compile with CGO on/off for testing

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,18 +16,10 @@ deploy:
     api_key:
       secure: 'rxcM8Ttmo0zTd2i+NBgG6YIDwtRwNCL28vPvAQ4GZ/SS7+8/fZn1RF8ZI2wWbZB2SqQveAiPmO66ZPXcGDsf/ynOHVvppn7IwJRSJoh2Z+QNu5i97JqQEtcM3DY5DZKO+scYqeCvINmLXmwSLHYDij/Nnu0hBXeobPizBDhqnN7AD0FZq2zbbCxZFPrAwUsB1G6wZTKWRFl4lX7baKDqyICc6OgGzb3m127SgrseW2zR6vBfHbc3Ep1hoIqjTf0vVXyDhCpDaIXAkZP43Jp1FxBwryrhEtPzx/46KWvPJLRwZc5gnRRrXX0HqrhlD577OxE/8VnjI+32mRTTNjSD8aOBraZ1Q71U5uLXLMoL1LD3qAfYv5sJaUKdbGtDkfGGwQ4X70A97gqmQI5gpYWU1LUksHwVJMwUqO2cPWciQikOTXQrDUT3qnuauZ432IP7izNhYmFWYwOEoQOzUA8pF1dl2jvUURY9dgQ2AHcJfCYV9C5TnBQ/2nO4Xbc96eo/Ky5OIX+lsfHx4bJmqvT6N+o/b9TJQYg3o4t0rqGB95Zt8/SbapvKlIU5I8SKGyuEpnKN4yUGAQRg8heuAPJ8mz3bmGriT9oC3q577vAqaCm2JcmvHCVx9OME0B04vLzxjYJXPHAi9CRmhUOZ8haHby3BkI3KYjnAaasUBot7oPI='
     file:
-      - dist/ghostunnel-${TRAVIS_TAG}-linux-386
-      - dist/ghostunnel-${TRAVIS_TAG}-linux-amd64
-      - dist/ghostunnel-${TRAVIS_TAG}-darwin-386
-      - dist/ghostunnel-${TRAVIS_TAG}-darwin-amd64
-      - dist/ghostunnel-${TRAVIS_TAG}-freebsd-386
-      - dist/ghostunnel-${TRAVIS_TAG}-freebsd-amd64
-      - dist/ghostunnel-${TRAVIS_TAG}-netbsd-386
-      - dist/ghostunnel-${TRAVIS_TAG}-netbsd-amd64
-      - dist/ghostunnel-${TRAVIS_TAG}-openbsd-386
-      - dist/ghostunnel-${TRAVIS_TAG}-openbsd-amd64
-      - dist/ghostunnel-${TRAVIS_TAG}-windows-386.exe
-      - dist/ghostunnel-${TRAVIS_TAG}-windows-amd64.exe
+      - dist/ghostunnel-${TRAVIS_TAG}-linux-amd64-with-pkcs11
+      - dist/ghostunnel-${TRAVIS_TAG}-darwin-amd64-with-pkcs11
+      - dist/ghostunnel-${TRAVIS_TAG}-windows-386-with-pkcs11.exe
+      - dist/ghostunnel-${TRAVIS_TAG}-windows-amd64-with-pkcs11.exe
     draft: true
     skip_cleanup: true
     on:

--- a/Makefile
+++ b/Makefile
@@ -5,33 +5,48 @@ INTEGRATION_TESTS := $(shell find tests -name 'test-*.py' -exec basename {} .py 
 ghostunnel.test: $(SOURCE_FILES)
 	go test -c -covermode=count -coverpkg .
 
+# Clean build output
 clean:
 	rm -rf *.out */*.out ghostunnel.test tests/__pycache__
 
+# Run all tests (unit + integration tests)
 test: unit $(INTEGRATION_TESTS)
 	gocovmerge *.out */*.out > coverage-merged.out
 	@echo "PASS"
+.PHONY: test
 
+# Run unit tests
 unit:
 	go test -v -covermode=count -coverprofile=coverage-unit-test-base.out .
 	go test -v -covermode=count -coverprofile=coverage-unit-test-auth.out ./auth
+.PHONY: unit
 
+# Run integration tests
 $(INTEGRATION_TESTS): ghostunnel.test
 	@cd tests && ./runner.py $@
+.PHONY: $(INTEGRATION_TESTS)
 
+# Import test keys into SoftHSM (v2)
 softhsm-import:
-	softhsm2-util --init-token --slot 0 --label ${GHOSTUNNEL_TEST_PKCS11_LABEL} --so-pin ${GHOSTUNNEL_TEST_PKCS11_PIN} --pin ${GHOSTUNNEL_TEST_PKCS11_PIN}
-	softhsm2-util --id 01 --token ${GHOSTUNNEL_TEST_PKCS11_LABEL} --label ${GHOSTUNNEL_TEST_PKCS11_LABEL} --import test-keys/server.pkcs8.key --so-pin ${GHOSTUNNEL_TEST_PKCS11_PIN} --pin ${GHOSTUNNEL_TEST_PKCS11_PIN}
+	softhsm2-util --init-token --slot 0 \
+		--label ${GHOSTUNNEL_TEST_PKCS11_LABEL} \
+		--so-pin ${GHOSTUNNEL_TEST_PKCS11_PIN} \
+		--pin ${GHOSTUNNEL_TEST_PKCS11_PIN}
+	softhsm2-util --id 01 \
+		--token ${GHOSTUNNEL_TEST_PKCS11_LABEL} \
+		--label ${GHOSTUNNEL_TEST_PKCS11_LABEL} \
+		--so-pin ${GHOSTUNNEL_TEST_PKCS11_PIN} \
+		--pin ${GHOSTUNNEL_TEST_PKCS11_PIN} \
+		--import test-keys/server.pkcs8.key
+.PHONY: softhsm-import
 
+# Build Docker image
 docker-build:
 	docker build -t squareup/ghostunnel .
+.PHONY: docker-build
 
-docker-test-build:
+# Run unit and integration tests in Docker container
+docker-test:
 	docker build --build-arg GO_VERSION=${GO_VERSION} -t squareup/ghostunnel-test -f Dockerfile-test .
-
-docker-test-run:
 	docker run -v ${PWD}:/go/src/github.com/square/ghostunnel squareup/ghostunnel-test
-
-docker-test: docker-test-build docker-test-run
-
-.PHONY: $(INTEGRATION_TESTS) test unit softhsm-import docker-build docker-test-build docker-test-run docker-test clean
+.PHONY: docker-test

--- a/Makefile.dist
+++ b/Makefile.dist
@@ -19,7 +19,7 @@ WINDOWS_EXTLD_386 = i686-w64-mingw-gcc
 PROJECT := $(CURRENT_DIR:$(GOPATH)/src/%=%)
 NAME := $(notdir $(PROJECT))
 GIT_COMMIT ?= $(shell git rev-parse --short HEAD)
-VERSION := $(shell awk -F\" '/version/ { print $$2; exit }' "${CURRENT_DIR}/main.go")
+VERSION ?= $(shell awk -F\" '/version/ { print $$2; exit }' "${CURRENT_DIR}/main.go")
 
 LD_FLAGS ?= \
 	-s \
@@ -80,7 +80,7 @@ $(foreach goarch,$(XC_ARCH),$(foreach goos,$(XC_OS),$(eval $(call make-xc-target
 dist:
 	@mkdir -p ${CURRENT_DIR}/dist
 	@$(MAKE) -f "${MKFILE_PATH}" _cleanup
-	@$(MAKE) -f "${MKFILE_PATH}" -j4 build
+	@$(MAKE) -f "${MKFILE_PATH}" -j1 build
 	@$(MAKE) -f "${MKFILE_PATH}" _checksum
 .PHONY: dist
 

--- a/Makefile.dist
+++ b/Makefile.dist
@@ -35,11 +35,11 @@ define make-xc-target
 		@printf "%s%20s %s\n" "-->" "${1}/${2}:" "${PROJECT} (-w -extldflags "-static" -extld ${WINDOWS_EXTLD_${2}})"
 		@xgo -go ${GOVERSION} -deps ${LIBTOOL_PATH} -targets '${1}-${WINDOWS_API_LEVEL}/${2}' \
 			-ldflags '-w -extldflags "-static" -extld ${WINDOWS_EXTLD_${2}}' .
-		@mkdir -p dist && mv ghostunnel-${1}-${WINDOWS_API_LEVEL}-${2}.exe dist/ghostunnel-${VERSION}-${1}-${2}.exe
+		@mkdir -p dist && mv ghostunnel-${1}-${WINDOWS_API_LEVEL}-${2}.exe dist/ghostunnel-${VERSION}-${1}-${2}-with-pkcs11.exe
   else
 		@printf "%s%20s %s\n" "-->" "${1}/${2}:" "${PROJECT}"
 		@xgo -go ${GOVERSION} -deps ${LIBTOOL_PATH} -targets '${1}/${2}' .
-		@mkdir -p dist && mv ghostunnel-${1}*-${2} dist/ghostunnel-${VERSION}-${1}-${2}
+		@mkdir -p dist && mv ghostunnel-${1}*-${2} dist/ghostunnel-${VERSION}-${1}-${2}-with-pkcs11
   endif
   .PHONY: $1/$2
 

--- a/Makefile.dist
+++ b/Makefile.dist
@@ -2,69 +2,44 @@
 MKFILE_PATH := $(lastword $(MAKEFILE_LIST))
 CURRENT_DIR := $(patsubst %/,%,$(dir $(realpath $(MKFILE_PATH))))
 
-GOVERSION ?= 1.10.0
+GOVERSION ?= 1.10
 
 # Current system information
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 
 # Default os-arch combination to build
-XC_OS ?= darwin freebsd linux netbsd openbsd windows
+XC_OS ?= darwin linux windows
 XC_ARCH ?= 386 amd64
+XC_EXCLUDE ?= darwin/386 linux/386
 
 # External linkers for Windows (to get a static exe with libltdl included)
-WINDOWS_EXTLD_amd64 = x86_64-w64-mingw-gcc
-WINDOWS_EXTLD_386 = i686-w64-mingw-gcc
+WINDOWS_EXTLD_amd64 = x86_64-w64-mingw32-gcc
+WINDOWS_EXTLD_386 = i686-w64-mingw32-gcc
+WINDOWS_API_LEVEL = 5.1
+LIBTOOL_PATH = https://ftp.gnu.org/pub/gnu/libtool/libtool-2.4.6.tar.gz
 
 PROJECT := $(CURRENT_DIR:$(GOPATH)/src/%=%)
 NAME := $(notdir $(PROJECT))
 GIT_COMMIT ?= $(shell git rev-parse --short HEAD)
-VERSION ?= $(shell awk -F\" '/version/ { print $$2; exit }' "${CURRENT_DIR}/main.go")
-
-LD_FLAGS ?= \
-	-s \
-	-X ${PROJECT}/version.Name=${NAME} \
-	-X ${PROJECT}/version.GitCommit=${GIT_COMMIT}
+VERSION ?= $(shell git describe --always)
 
 # Create a cross-compile target for every os-arch pairing. This will generate
 # a make target for each os/arch like "make linux/amd64" as well as generate a
 # meta target (build) for compiling everything.
 define make-xc-target
   $1/$2:
-  ifeq (${1},windows)
-	@printf "%s%20s %s\n" "-->" "${1}/${2}:" "${PROJECT} (-w -extldflags "-static" -extld ${WINDOWS_EXTLD_${2}})"
-	@docker run \
-		--interactive \
-		--rm \
-		--volume="${CURRENT_DIR}:/go/src/${PROJECT}" \
-		--workdir="/go/src/${PROJECT}" \
-		"golang:${GOVERSION}" \
-		env \
-			CGO_ENABLED="0" \
-			GOOS="${1}" \
-			GOARCH="${2}" \
-			go build \
-			  -a \
-				-o="dist/${NAME}-${VERSION}-${1}-${2}.exe" \
-				-ldflags "${LD_FLAGS} -w -extldflags "-static" -extld ${WINDOWS_EXTLD_${2}}" \
-				-tags "${GOTAGS}"
+  ifneq (,$(findstring ${1}/${2},$(XC_EXCLUDE)))
+		@printf "%s%20s %s\n" "-->" "${1}/${2}:" "${PROJECT} (excluded)"
+  else ifeq (${1},windows)
+		@printf "%s%20s %s\n" "-->" "${1}/${2}:" "${PROJECT} (-w -extldflags "-static" -extld ${WINDOWS_EXTLD_${2}})"
+		@xgo -go ${GOVERSION} -deps ${LIBTOOL_PATH} -targets '${1}-${WINDOWS_API_LEVEL}/${2}' \
+			-ldflags '-w -extldflags "-static" -extld ${WINDOWS_EXTLD_${2}}' .
+		@mkdir -p dist && mv ghostunnel-${1}-${WINDOWS_API_LEVEL}-${2}.exe dist/ghostunnel-${VERSION}-${1}-${2}.exe
   else
-	@printf "%s%20s %s\n" "-->" "${1}/${2}:" "${PROJECT}"
-	@docker run \
-		--interactive \
-		--rm \
-		--volume="${CURRENT_DIR}:/go/src/${PROJECT}" \
-		--workdir="/go/src/${PROJECT}" \
-		"golang:${GOVERSION}" \
-		env \
-			CGO_ENABLED="0" \
-			GOOS="${1}" \
-			GOARCH="${2}" \
-			go build \
-			  -a \
-				-o="dist/${NAME}-${VERSION}-${1}-${2}" \
-				-ldflags "${LD_FLAGS}" \
-				-tags "${GOTAGS}"
+		@printf "%s%20s %s\n" "-->" "${1}/${2}:" "${PROJECT}"
+		@xgo -go ${GOVERSION} -deps ${LIBTOOL_PATH} -targets '${1}/${2}' .
+		@mkdir -p dist && mv ghostunnel-${1}*-${2} dist/ghostunnel-${VERSION}-${1}-${2}
   endif
   .PHONY: $1/$2
 
@@ -78,7 +53,6 @@ $(foreach goarch,$(XC_ARCH),$(foreach goos,$(XC_OS),$(eval $(call make-xc-target
 
 # dist builds the binaries for distribution
 dist:
-	@mkdir -p ${CURRENT_DIR}/dist
 	@$(MAKE) -f "${MKFILE_PATH}" _cleanup
 	@$(MAKE) -f "${MKFILE_PATH}" -j1 build
 	@$(MAKE) -f "${MKFILE_PATH}" _checksum

--- a/Makefile.dist
+++ b/Makefile.dist
@@ -35,11 +35,11 @@ define make-xc-target
 		@printf "%s%20s %s\n" "-->" "${1}/${2}:" "${PROJECT} (-w -extldflags "-static" -extld ${WINDOWS_EXTLD_${2}})"
 		@xgo -go ${GOVERSION} -deps ${LIBTOOL_PATH} -targets '${1}-${WINDOWS_API_LEVEL}/${2}' \
 			-ldflags '-w -extldflags "-static" -extld ${WINDOWS_EXTLD_${2}}' .
-		@mkdir -p dist && mv ghostunnel-${1}-${WINDOWS_API_LEVEL}-${2}.exe dist/ghostunnel-${VERSION}-${1}-${2}-with-pkcs11.exe
+		@mv ghostunnel-${1}-${WINDOWS_API_LEVEL}-${2}.exe dist/ghostunnel-${VERSION}-${1}-${2}-with-pkcs11.exe
   else
 		@printf "%s%20s %s\n" "-->" "${1}/${2}:" "${PROJECT}"
 		@xgo -go ${GOVERSION} -deps ${LIBTOOL_PATH} -targets '${1}/${2}' .
-		@mkdir -p dist && mv ghostunnel-${1}*-${2} dist/ghostunnel-${VERSION}-${1}-${2}-with-pkcs11
+		@mv ghostunnel-${1}*-${2} dist/ghostunnel-${VERSION}-${1}-${2}-with-pkcs11
   endif
   .PHONY: $1/$2
 
@@ -53,19 +53,7 @@ $(foreach goarch,$(XC_ARCH),$(foreach goos,$(XC_OS),$(eval $(call make-xc-target
 
 # dist builds the binaries for distribution
 dist:
-	@$(MAKE) -f "${MKFILE_PATH}" _cleanup
-	@$(MAKE) -f "${MKFILE_PATH}" -j1 build
-	@$(MAKE) -f "${MKFILE_PATH}" _checksum
-.PHONY: dist
-
-# _checksum produces the checksums for the binaries in dist
-_checksum:
-	@cd "${CURRENT_DIR}/dist" && \
-		shasum --algorithm 256 * > ${CURRENT_DIR}/dist/${NAME}-${VERSION}-sha256sums.txt && \
-		cd - &>/dev/null
-.PHONY: _checksum
-
-# _cleanup removes any previous binaries
-_cleanup:
 	@rm -rf "${CURRENT_DIR}/dist/"
-.PHONY: _cleanup
+	@mkdir -p "${CURRENT_DIR}/dist/"
+	@$(MAKE) -f "${MKFILE_PATH}" -j1 build
+.PHONY: dist

--- a/Makefile.dist
+++ b/Makefile.dist
@@ -1,0 +1,131 @@
+# Metadata about this makefile and position
+MKFILE_PATH := $(lastword $(MAKEFILE_LIST))
+CURRENT_DIR := $(patsubst %/,%,$(dir $(realpath $(MKFILE_PATH))))
+
+GOVERSION := 1.10.0
+
+# Current system information
+GOOS ?= $(shell go env GOOS)
+GOARCH ?= $(shell go env GOARCH)
+
+# Default os-arch combination to build
+XC_OS ?= darwin freebsd linux netbsd openbsd solaris windows
+XC_ARCH ?= 386 amd64
+XC_EXCLUDE ?= solaris/386 solaris/amd64
+
+PROJECT := $(CURRENT_DIR:$(GOPATH)/src/%=%)
+NAME := $(notdir $(PROJECT))
+GIT_COMMIT ?= $(shell git rev-parse --short HEAD)
+VERSION := $(shell awk -F\" '/version/ { print $$2; exit }' "${CURRENT_DIR}/main.go")
+
+LD_FLAGS ?= \
+	-s \
+	-w -extldflags "-static" -extld x86_64-w64-mingw32-gcc \
+	-X ${PROJECT}/version.Name=${NAME} \
+	-X ${PROJECT}/version.GitCommit=${GIT_COMMIT}
+
+clean:
+	rm -rf *.out */*.out ghostunnel.test tests/__pycache__
+
+# bootstrap installs the necessary go tools for development or build.
+bootstrap:
+	@echo "==> Bootstrapping ${PROJECT}"
+	@for t in ${EXTERNAL_TOOLS}; do \
+		echo "--> Installing $$t" ; \
+		go get -u "$$t"; \
+	done
+.PHONY: bootstrap
+
+# Create a cross-compile target for every os-arch pairing. This will generate
+# a make target for each os/arch like "make linux/amd64" as well as generate a
+# meta target (build) for compiling everything.
+define make-xc-target
+  $1/$2:
+  ifneq (,$(findstring ${1}/${2},$(XC_EXCLUDE)))
+	@printf "%s%20s %s\n" "-->" "${1}/${2}:" "${PROJECT} (excluded)"
+  else ifeq (${1},windows)
+	@printf "%s%20s %s\n" "-->" "${1}/${2}:" "${PROJECT} (-w -extldflags "-static" -extld x86_64-w64-mingw32-gcc}"
+	@docker run \
+	        --interactive \
+	        --rm \
+	        --dns="8.8.8.8" \
+	        --volume="${CURRENT_DIR}:/go/src/${PROJECT}" \
+	        --workdir="/go/src/${PROJECT}" \
+	        "golang:${GOVERSION}" \
+	        env \
+	                CGO_ENABLED="0" \
+	                GOOS="${1}" \
+	                GOARCH="${2}" \
+	                go build \
+	                  -a \
+	                        -o="pkg/${1}_${2}/${NAME}${3}" \
+	                        -ldflags "${LD_FLAGS} -w -extldflags "-static" -extld x86_64-w64-mingw32-gcc" \
+	                        -tags "${GOTAGS}"
+  else
+	@printf "%s%20s %s\n" "-->" "${1}/${2}:" "${PROJECT}"
+	@docker run \
+		--interactive \
+		--rm \
+		--dns="8.8.8.8" \
+		--volume="${CURRENT_DIR}:/go/src/${PROJECT}" \
+		--workdir="/go/src/${PROJECT}" \
+		"golang:${GOVERSION}" \
+		env \
+			CGO_ENABLED="0" \
+			GOOS="${1}" \
+			GOARCH="${2}" \
+			go build \
+			  -a \
+				-o="pkg/${1}_${2}/${NAME}${3}" \
+				-ldflags "${LD_FLAGS}" \
+				-tags "${GOTAGS}"
+  endif
+  .PHONY: $1/$2
+
+  $1:: $1/$2
+  .PHONY: $1
+
+  build:: $1/$2
+  .PHONY: build
+endef
+$(foreach goarch,$(XC_ARCH),$(foreach goos,$(XC_OS),$(eval $(call make-xc-target,$(goos),$(goarch),$(if $(findstring windows,$(goos)),.exe,)))))
+
+# dist builds the binaries and then signs and packages them for distribution
+dist:
+	@$(MAKE) -f "${MKFILE_PATH}" _cleanup
+	@$(MAKE) -f "${MKFILE_PATH}" -j4 build
+	@$(MAKE) -f "${MKFILE_PATH}" _compress _checksum
+.PHONY: dist
+
+# _compress compresses all the binaries in pkg/* as tarball and zip.
+_compress:
+	@mkdir -p "${CURRENT_DIR}/pkg/dist"
+	@for platform in $$(find ./pkg -mindepth 1 -maxdepth 1 -type d); do \
+		osarch=$$(basename "$$platform"); \
+		if [ "$$osarch" = "dist" ]; then \
+			continue; \
+		fi; \
+		\
+		ext=""; \
+		if test -z "$${osarch##*windows*}"; then \
+			ext=".exe"; \
+		fi; \
+		cd "$$platform"; \
+		tar -czf "${CURRENT_DIR}/pkg/dist/${NAME}_${VERSION}_$${osarch}.tgz" "${NAME}$${ext}"; \
+		zip -q "${CURRENT_DIR}/pkg/dist/${NAME}_${VERSION}_$${osarch}.zip" "${NAME}$${ext}"; \
+		cd - &>/dev/null; \
+	done
+.PHONY: _compress
+
+# _checksum produces the checksums for the binaries in pkg/dist
+_checksum:
+	@cd "${CURRENT_DIR}/pkg/dist" && \
+		shasum --algorithm 256 * > ${CURRENT_DIR}/pkg/dist/${NAME}_${VERSION}_SHA256SUMS && \
+		cd - &>/dev/null
+.PHONY: _checksum
+
+# _cleanup removes any previous binaries
+_cleanup:
+	@rm -rf "${CURRENT_DIR}/pkg/"
+	@rm -rf "${CURRENT_DIR}/bin/"
+.PHONY: _cleanup

--- a/Makefile.dist
+++ b/Makefile.dist
@@ -2,16 +2,19 @@
 MKFILE_PATH := $(lastword $(MAKEFILE_LIST))
 CURRENT_DIR := $(patsubst %/,%,$(dir $(realpath $(MKFILE_PATH))))
 
-GOVERSION := 1.10.0
+GOVERSION ?= 1.10.0
 
 # Current system information
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 
 # Default os-arch combination to build
-XC_OS ?= darwin freebsd linux netbsd openbsd solaris windows
+XC_OS ?= darwin freebsd linux netbsd openbsd windows
 XC_ARCH ?= 386 amd64
-XC_EXCLUDE ?= solaris/386 solaris/amd64
+
+# External linkers for Windows (to get a static exe with libltdl included)
+WINDOWS_EXTLD_amd64 = x86_64-w64-mingw-gcc
+WINDOWS_EXTLD_386 = i686-w64-mingw-gcc
 
 PROJECT := $(CURRENT_DIR:$(GOPATH)/src/%=%)
 NAME := $(notdir $(PROJECT))
@@ -20,53 +23,19 @@ VERSION := $(shell awk -F\" '/version/ { print $$2; exit }' "${CURRENT_DIR}/main
 
 LD_FLAGS ?= \
 	-s \
-	-w -extldflags "-static" -extld x86_64-w64-mingw32-gcc \
 	-X ${PROJECT}/version.Name=${NAME} \
 	-X ${PROJECT}/version.GitCommit=${GIT_COMMIT}
-
-clean:
-	rm -rf *.out */*.out ghostunnel.test tests/__pycache__
-
-# bootstrap installs the necessary go tools for development or build.
-bootstrap:
-	@echo "==> Bootstrapping ${PROJECT}"
-	@for t in ${EXTERNAL_TOOLS}; do \
-		echo "--> Installing $$t" ; \
-		go get -u "$$t"; \
-	done
-.PHONY: bootstrap
 
 # Create a cross-compile target for every os-arch pairing. This will generate
 # a make target for each os/arch like "make linux/amd64" as well as generate a
 # meta target (build) for compiling everything.
 define make-xc-target
   $1/$2:
-  ifneq (,$(findstring ${1}/${2},$(XC_EXCLUDE)))
-	@printf "%s%20s %s\n" "-->" "${1}/${2}:" "${PROJECT} (excluded)"
-  else ifeq (${1},windows)
-	@printf "%s%20s %s\n" "-->" "${1}/${2}:" "${PROJECT} (-w -extldflags "-static" -extld x86_64-w64-mingw32-gcc}"
-	@docker run \
-	        --interactive \
-	        --rm \
-	        --dns="8.8.8.8" \
-	        --volume="${CURRENT_DIR}:/go/src/${PROJECT}" \
-	        --workdir="/go/src/${PROJECT}" \
-	        "golang:${GOVERSION}" \
-	        env \
-	                CGO_ENABLED="0" \
-	                GOOS="${1}" \
-	                GOARCH="${2}" \
-	                go build \
-	                  -a \
-	                        -o="pkg/${1}_${2}/${NAME}${3}" \
-	                        -ldflags "${LD_FLAGS} -w -extldflags "-static" -extld x86_64-w64-mingw32-gcc" \
-	                        -tags "${GOTAGS}"
-  else
-	@printf "%s%20s %s\n" "-->" "${1}/${2}:" "${PROJECT}"
+  ifeq (${1},windows)
+	@printf "%s%20s %s\n" "-->" "${1}/${2}:" "${PROJECT} (-w -extldflags "-static" -extld ${WINDOWS_EXTLD_${2}})"
 	@docker run \
 		--interactive \
 		--rm \
-		--dns="8.8.8.8" \
 		--volume="${CURRENT_DIR}:/go/src/${PROJECT}" \
 		--workdir="/go/src/${PROJECT}" \
 		"golang:${GOVERSION}" \
@@ -76,7 +45,24 @@ define make-xc-target
 			GOARCH="${2}" \
 			go build \
 			  -a \
-				-o="pkg/${1}_${2}/${NAME}${3}" \
+				-o="dist/${NAME}-${VERSION}-${1}-${2}.exe" \
+				-ldflags "${LD_FLAGS} -w -extldflags "-static" -extld ${WINDOWS_EXTLD_${2}}" \
+				-tags "${GOTAGS}"
+  else
+	@printf "%s%20s %s\n" "-->" "${1}/${2}:" "${PROJECT}"
+	@docker run \
+		--interactive \
+		--rm \
+		--volume="${CURRENT_DIR}:/go/src/${PROJECT}" \
+		--workdir="/go/src/${PROJECT}" \
+		"golang:${GOVERSION}" \
+		env \
+			CGO_ENABLED="0" \
+			GOOS="${1}" \
+			GOARCH="${2}" \
+			go build \
+			  -a \
+				-o="dist/${NAME}-${VERSION}-${1}-${2}" \
 				-ldflags "${LD_FLAGS}" \
 				-tags "${GOTAGS}"
   endif
@@ -90,42 +76,22 @@ define make-xc-target
 endef
 $(foreach goarch,$(XC_ARCH),$(foreach goos,$(XC_OS),$(eval $(call make-xc-target,$(goos),$(goarch),$(if $(findstring windows,$(goos)),.exe,)))))
 
-# dist builds the binaries and then signs and packages them for distribution
+# dist builds the binaries for distribution
 dist:
+	@mkdir -p ${CURRENT_DIR}/dist
 	@$(MAKE) -f "${MKFILE_PATH}" _cleanup
 	@$(MAKE) -f "${MKFILE_PATH}" -j4 build
-	@$(MAKE) -f "${MKFILE_PATH}" _compress _checksum
+	@$(MAKE) -f "${MKFILE_PATH}" _checksum
 .PHONY: dist
 
-# _compress compresses all the binaries in pkg/* as tarball and zip.
-_compress:
-	@mkdir -p "${CURRENT_DIR}/pkg/dist"
-	@for platform in $$(find ./pkg -mindepth 1 -maxdepth 1 -type d); do \
-		osarch=$$(basename "$$platform"); \
-		if [ "$$osarch" = "dist" ]; then \
-			continue; \
-		fi; \
-		\
-		ext=""; \
-		if test -z "$${osarch##*windows*}"; then \
-			ext=".exe"; \
-		fi; \
-		cd "$$platform"; \
-		tar -czf "${CURRENT_DIR}/pkg/dist/${NAME}_${VERSION}_$${osarch}.tgz" "${NAME}$${ext}"; \
-		zip -q "${CURRENT_DIR}/pkg/dist/${NAME}_${VERSION}_$${osarch}.zip" "${NAME}$${ext}"; \
-		cd - &>/dev/null; \
-	done
-.PHONY: _compress
-
-# _checksum produces the checksums for the binaries in pkg/dist
+# _checksum produces the checksums for the binaries in dist
 _checksum:
-	@cd "${CURRENT_DIR}/pkg/dist" && \
-		shasum --algorithm 256 * > ${CURRENT_DIR}/pkg/dist/${NAME}_${VERSION}_SHA256SUMS && \
+	@cd "${CURRENT_DIR}/dist" && \
+		shasum --algorithm 256 * > ${CURRENT_DIR}/dist/${NAME}-${VERSION}-sha256sums.txt && \
 		cd - &>/dev/null
 .PHONY: _checksum
 
 # _cleanup removes any previous binaries
 _cleanup:
-	@rm -rf "${CURRENT_DIR}/pkg/"
-	@rm -rf "${CURRENT_DIR}/bin/"
+	@rm -rf "${CURRENT_DIR}/dist/"
 .PHONY: _cleanup

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ a TLS-secured service. In other words, ghostunnel is a replacement for stunnel.
 
 **Supported platforms**: Ghostunnel is developed primarily for Linux on x86-64
 platforms, although it should run on any UNIX system that exposes SO_REUSEPORT,
-including Darwin (macOS), FreeBSD, OpenBSD and NetBSD. We recommend running on
+including Darwin (macOS), FreeBSD, OpenBSD and NetBSD. Ghostunnel also supports
+running on Windows, through with a reduced feature set. We recommend running on
 x86-64 only, to benefit from constant-time implementations of cryptographic
 algorithms that are not available on other platforms.
 


### PR DESCRIPTION
Continuation of #154:
* Hook Makefile.dist into Travis-CI
* Skip compression of artifacts since it's just one file per arch
* Use karalabe/xgo again to get cross-compile with PKCS11 (CGO must be enabled)
* Skip builds for BSD platforms since it's not supported by xgo at the moment
* Skip 386 build for linux/darwin (shouldn't bother with 32-bit on those platforms)

In effect, this builds linux/amd64, darwin/amd64, windows/{386,amd64} (with 5.1 API level).