### PR TITLE
Set version through ldflags

### DIFF
--- a/CROSS-COMPILE.md
+++ b/CROSS-COMPILE.md
@@ -19,6 +19,9 @@ For example, to build a static 64-bit Windows binary:
       -ldflags '-w -extldflags "-static" -extld x86_64-w64-mingw32-gcc' \
       github.com/square/ghostunnel
 
-For more info, see [xgo][xgo]'s README on GitHub.
+Ghostunnel ships with a `Makefile.dist` that will cross-compile for
+darwin/amd64, linux/amd64, windows/386 and windows/amd64 when asked to build
+the `dist` target. Note that [xgo][xgo] (and Docker) must already be installed
+to run this. For more info, see also [xgo][xgo]'s README on GitHub.
 
 [xgo]: https://github.com/karalabe/xgo

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 SOURCE_FILES := $(shell find . \( -name '*.go' -not -path './vendor*' \))
 INTEGRATION_TESTS := $(shell find tests -name 'test-*.py' -exec basename {} .py \;)
+VERSION := $(shell git describe --always --dirty)
+
+# Ghostunnel binary
+ghostunnel: $(SOURCE_FILES)
+	go build -ldflags '-X main.version=${VERSION}' -o ghostunnel .
 
 # Test binary with coverage instrumentation
 ghostunnel.test: $(SOURCE_FILES)

--- a/Makefile.dist
+++ b/Makefile.dist
@@ -23,6 +23,7 @@ PROJECT := $(CURRENT_DIR:$(GOPATH)/src/%=%)
 NAME := $(notdir $(PROJECT))
 GIT_COMMIT ?= $(shell git rev-parse --short HEAD)
 VERSION ?= $(shell git describe --always)
+LD_FLAGS := -X main.version=${VERSION}
 
 # Create a cross-compile target for every os-arch pairing. This will generate
 # a make target for each os/arch like "make linux/amd64" as well as generate a
@@ -34,11 +35,11 @@ define make-xc-target
   else ifeq (${1},windows)
 		@printf "%s%20s %s\n" "-->" "${1}/${2}:" "${PROJECT} (-w -extldflags "-static" -extld ${WINDOWS_EXTLD_${2}})"
 		@xgo -go ${GOVERSION} -deps ${LIBTOOL_PATH} -targets '${1}-${WINDOWS_API_LEVEL}/${2}' \
-			-ldflags '-w -extldflags "-static" -extld ${WINDOWS_EXTLD_${2}}' .
+			-ldflags '${LD_FLAGS} -w -extldflags "-static" -extld ${WINDOWS_EXTLD_${2}}' .
 		@mv ghostunnel-${1}-${WINDOWS_API_LEVEL}-${2}.exe dist/ghostunnel-${VERSION}-${1}-${2}-with-pkcs11.exe
   else
 		@printf "%s%20s %s\n" "-->" "${1}/${2}:" "${PROJECT}"
-		@xgo -go ${GOVERSION} -deps ${LIBTOOL_PATH} -targets '${1}/${2}' .
+		@xgo -go ${GOVERSION} -deps ${LIBTOOL_PATH} -ldflags "${LD_FLAGS}" -targets '${1}/${2}' .
 		@mv ghostunnel-${1}*-${2} dist/ghostunnel-${VERSION}-${1}-${2}-with-pkcs11
   endif
   .PHONY: $1/$2

--- a/README.md
+++ b/README.md
@@ -65,10 +65,21 @@ on how to generate new ones with OpenSSL).
 
 Ghostunnel is available through [GitHub releases][rel] and through [Docker Hub][hub].
 
-Note that ghostunnel requires Go 1.9 or later to build, and CGO is required for PKCS#11 support.
+Binaries can be built from source as follows (cross-compile requires Docker and [xgo][xgo]):
+
+    # Compile for local architecture
+    make ghostunnel
+
+    # Cross-compile release binaries
+    make -f Makefile.dist dist
+
+Note that ghostunnel requires Go 1.9 or later to build, and CGO is required for
+PKCS#11 support.  See also [CROSS-COMPILE.md](CROSS-COMPILE.md) for
+instructions on how to cross-compile a custom build with CGO enabled.
 
 [rel]: https://github.com/square/ghostunnel/releases
 [hub]: https://hub.docker.com/r/squareup/ghostunnel
+[xgo]: https://github.com/karalabe/xgo
 
 ### Develop
 

--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ import (
 )
 
 var (
-	version              = "v1.2.0-rc.2"
+	version              = "master"
 	defaultMetricsPrefix = "ghostunnel"
 )
 


### PR DESCRIPTION
Set version through ldflags, via Makefile.dist, so we don't have to manually bump the version global anymore. 