### PR TITLE
Default to long help.

### DIFF
--- a/main.go
+++ b/main.go
@@ -232,6 +232,7 @@ func run(args []string) error {
 
 	app.Version(fmt.Sprintf("rev %s built with %s", version, runtime.Version()))
 	app.Validate(validateFlags)
+	app.UsageTemplate(kingpin.LongHelpTemplate)
 	command := kingpin.MustParse(app.Parse(args))
 
 	// Logger


### PR DESCRIPTION
Because ghostunnel's usage is relatively compact and most useful params are on
a subcommand, default to long help