### PR TITLE
Ghostunnel without authentication

### DIFF
--- a/main.go
+++ b/main.go
@@ -277,7 +277,7 @@ func run(args []string) error {
 		go watchFiles([]string{*keystorePath}, *timedReload, watcher)
 	}
 
-	if (*keystorePath == "") && !(*clientDisableAuth) {
+	if (*keystorePath == "") && !(*clientDisableAuth) && !(*serverDisableAuth) {
 		fmt.Printf("one of --keystore or --disable-authentication is required, try --help\n")
 		return fmt.Errorf("one of --keystore or --disable-authentication is required, try --help")
 	}

--- a/main.go
+++ b/main.go
@@ -203,6 +203,11 @@ func serverValidateFlags() error {
 
 // Validate flags for client mode
 func clientValidateFlags() error {
+	if (*keystorePath == "") && !(*clientDisableAuth) {
+		fmt.Printf("one of --keystore or --disable-authentication is required, try --help\n")
+		return fmt.Errorf("one of --keystore or --disable-authentication is required, try --help")
+	}
+
 	if !*clientUnsafeListen && !validateUnixOrLocalhost(*clientListenAddress) {
 		return fmt.Errorf("--listen must be unix:PATH, localhost:PORT, 127.0.0.1:PORT or [::1]:PORT (unless --unsafe-listen is set)")
 	}
@@ -275,11 +280,6 @@ func run(args []string) error {
 	watcher := make(chan bool, 1)
 	if *timedReload > 0 {
 		go watchFiles([]string{*keystorePath}, *timedReload, watcher)
-	}
-
-	if (*keystorePath == "") && !(*clientDisableAuth) && !(*serverDisableAuth) {
-		fmt.Printf("one of --keystore or --disable-authentication is required, try --help\n")
-		return fmt.Errorf("one of --keystore or --disable-authentication is required, try --help")
 	}
 
 	cert, err := buildCertificate(*keystorePath, *keystorePass)


### PR DESCRIPTION
Fixes a bug you encounter when you run:

```
$ ./ghostunnel server --listen localhost:8443 --target localhost:8080 --disable-authentication

[5392] 2018/03/30 14:14:19.039912 starting ghostunnel in server mode
one of --keystore or --disable-authentication is required, try --help
```

The current code base checks `(*keystorePath == "") && !(*clientDisableAuth)` in all modes, server or client. Moved the check to inside the client checks.
