### PR TITLE
Add some more info about PKCS11 modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ To launch ghostunnel with the SoftHSM-backed PKCS11 key (on macOS):
 
     ghostunnel server \
         --keystore test-keys/server-cert.pem \
-        --pkcs11-module /usr/local/Cellar/softhsm/2.3.0/lib/softhsm/libsofthsm2.so \
+        --pkcs11-module /usr/local/Cellar/softhsm/2.4.0/lib/softhsm/libsofthsm2.so \
         --pkcs11-token-label ghostunnel-server \
         --pkcs11-pin 1234 \
         --listen localhost:8443 \
@@ -317,13 +317,31 @@ To launch ghostunnel with the SoftHSM-backed PKCS11 key (on macOS):
         --cacert test-keys/cacert.pem \
         --allow-cn client
 
+The `--pkcs11-module`, `--pkcs11-token-label` and `--pkcs11-pin` flags can be
+used to select the private key to be used the PKCS11 module. It's also possible
+to use environment variables to set PKCS11 options instead of flags (via
+`PKCS11_MODULE`, `PKCS11_TOKEN_LABEL` and `PKCS11_PIN`), useful if you don't
+want to show the PIN on the command line.
+
 Note that `--keystore` needs to point to the certificate chain that corresponds
 to the private key in the PKCS#11 module, with the leaf certificate being the
-first certificate in the chain. The `--pkcs11-module`, `--pkcs11-token-label`
-and `--pkcs11-pin` flags can be used to configure how to load the key from the
-PKCS11 module you are using. It's also possible to use environment variables to
-set PKCS11 options instead of flags (via `PKCS11_MODULE`, `PKCS11_TOKEN_LABEL`
-and `PKCS11_PIN`).
+first certificate in the chain. Ghostunnel doesn't have the ability to read
+the certificate chain directly from the module at this point in time.
+
+If you need to inspect the state of a PKCS11 module/token, we recommend the
+[`pkcs11-tool`][pkcs11-tool] utility from OpenSC. For example, it can be used
+to list slots or read certificate(s) from a module:
+
+    # List slots on a module
+    pkcs11-tool --module $MODULE -L
+
+    # Show certificates (if any) available
+    pkcs11-tool --module $MODULE -O -y cert
+
+    # Read certificate chain given a label
+    pkcs11-tool --module $MODULE --label $LABEL --read-object -y cert
+
+[pkcs11-tool]: https://github.com/OpenSC/OpenSC/wiki/SmartCardHSM#using-pkcs11-tool
 
 ### macOS keychain support (experimental)
 


### PR DESCRIPTION
Improve the docs for PKCS11 a bit, adds some examples for how to use pkcs11-tool to list slots or read certificates from a token since ghostunnel can't directly read certs off of the module right now.