### PR TITLE
Wildcard/pattern matching for allowed URIs

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -42,4 +42,4 @@ build_script:
   - set CGO_ENABLED=1
   - go build -o ghostunnel-%GIT_VERSION%-windows-%GOARCH%-with-pkcs11.exe -ldflags "-w -extldflags \"-static\" -extld=%EXTLD%" -i .
   # Execute tests
-  - go test -v . ./auth ./certloader ./proxy ./wildcard
+  - go test -v ./...

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -42,4 +42,4 @@ build_script:
   - set CGO_ENABLED=1
   - go build -o ghostunnel-%GIT_VERSION%-windows-%GOARCH%-with-pkcs11.exe -ldflags "-w -extldflags \"-static\" -extld=%EXTLD%" -i .
   # Execute tests
-  - go test -v . ./auth
+  - go test -v . ./auth ./certloader ./proxy ./wildcard

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ unit:
 	go test -v -covermode=count -coverprofile=coverage-unit-test-auth.out ./auth
 	go test -v -covermode=count -coverprofile=coverage-unit-test-certloader.out ./certloader
 	go test -v -covermode=count -coverprofile=coverage-unit-test-proxy.out ./proxy
+	go test -v -covermode=count -coverprofile=coverage-unit-test-wildcard.out ./wildcard
 .PHONY: unit
 
 # Run integration tests

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -21,6 +21,8 @@ import (
 	"errors"
 	"net"
 	"net/url"
+
+	"github.com/square/ghostunnel/wildcard"
 )
 
 // Logger is used by this package to log messages
@@ -53,7 +55,7 @@ type ACL struct {
 	// AllowURIs lists URI SANs that should be allowed access. If a principal
 	// has a valid certificate with at least one of these URI SANs, we grant
 	// access.
-	AllowedURIs []string
+	AllowedURIs []wildcard.Matcher
 	// Logger is used to log authorization decisions.
 	Logger Logger
 }
@@ -181,10 +183,10 @@ func intersectsIP(left, right []net.IP) bool {
 }
 
 // Returns true if at least one item from left is also contained in right.
-func intersectsURI(left []string, right []*url.URL) bool {
+func intersectsURI(left []wildcard.Matcher, right []*url.URL) bool {
 	for _, l := range left {
 		for _, r := range right {
-			if r.String() == l {
+			if l.Matches(r.String()) {
 				return true
 			}
 		}

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/square/ghostunnel/wildcard"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -55,7 +56,7 @@ func TestAuthorizeReject(t *testing.T) {
 		AllowedCNs:  []string{"test"},
 		AllowedOUs:  []string{"test"},
 		AllowedDNSs: []string{"test"},
-		AllowedURIs: []string{"test"},
+		AllowedURIs: []wildcard.Matcher{wildcard.MustCompile("test")},
 	}
 
 	assert.NotNil(t, testACL.VerifyPeerCertificateServer(nil, fakeChains), "should reject cert w/o matching CN/OU")
@@ -103,7 +104,7 @@ func TestAuthorizeAllowIP(t *testing.T) {
 
 func TestAuthorizeAllowURI(t *testing.T) {
 	testACL := ACL{
-		AllowedURIs: []string{"scheme://valid/path"},
+		AllowedURIs: []wildcard.Matcher{wildcard.MustCompile("scheme://valid/path")},
 	}
 
 	assert.Nil(t, testACL.VerifyPeerCertificateServer(nil, fakeChains), "allow-uri-san should allow clients with matching URI SAN")
@@ -111,7 +112,7 @@ func TestAuthorizeAllowURI(t *testing.T) {
 
 func TestAuthorizeRejectURI(t *testing.T) {
 	testACL := ACL{
-		AllowedURIs: []string{"schema://invalid/path"},
+		AllowedURIs: []wildcard.Matcher{wildcard.MustCompile("scheme://invalid/path")},
 	}
 
 	assert.NotNil(t, testACL.VerifyPeerCertificateServer(nil, fakeChains), "should reject cert w/o matching URI")
@@ -192,7 +193,7 @@ func TestVerifyRejectIP(t *testing.T) {
 
 func TestVerifyAllowURI(t *testing.T) {
 	testACL := ACL{
-		AllowedURIs: []string{"scheme://valid/path"},
+		AllowedURIs: []wildcard.Matcher{wildcard.MustCompile("scheme://valid/path")},
 	}
 
 	assert.Nil(t, testACL.VerifyPeerCertificateClient(nil, fakeChains), "verify-uri-san should allow clients with matching URI SAN")
@@ -200,7 +201,7 @@ func TestVerifyAllowURI(t *testing.T) {
 
 func TestVerifyRejectURI(t *testing.T) {
 	testACL := ACL{
-		AllowedURIs: []string{"scheme://invalid/path"},
+		AllowedURIs: []wildcard.Matcher{wildcard.MustCompile("scheme://invalid/path")},
 	}
 
 	assert.NotNil(t, testACL.VerifyPeerCertificateClient(nil, fakeChains), "should reject cert w/o matching URI")

--- a/certloader/keystore_test.go
+++ b/certloader/keystore_test.go
@@ -20,6 +20,7 @@ import (
 	"crypto/tls"
 	"io/ioutil"
 	"os"
+	"runtime"
 	"testing"
 	"unsafe"
 
@@ -95,6 +96,11 @@ func TestCertificateFromPEMFilesValid(t *testing.T) {
 	assert.Nil(t, cert.Reload(), "should be able to reload")
 
 	// Remove file & test reload failure
+	if runtime.GOOS == "windows" {
+		// Reloading not supported on Windows
+		return
+	}
+
 	os.Remove(file.Name())
 	assert.NotNil(t, cert.Reload(), "should not be able to reload")
 }

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ import (
 	"github.com/square/ghostunnel/auth"
 	"github.com/square/ghostunnel/certloader"
 	"github.com/square/ghostunnel/proxy"
+	"github.com/square/ghostunnel/wildcard"
 	"github.com/square/go-sq-metrics"
 	"gopkg.in/alecthomas/kingpin.v2"
 
@@ -389,13 +390,19 @@ func serverListen(context *Context) error {
 		return err
 	}
 
+	allowedURIs, err := wildcard.CompileList(*serverAllowedURIs)
+	if err != nil {
+		logger.Printf("invalid URI pattern in --allow-uri flag (%s)", err)
+		return err
+	}
+
 	serverACL := auth.ACL{
 		AllowAll:    *serverAllowAll,
 		AllowedCNs:  *serverAllowedCNs,
 		AllowedOUs:  *serverAllowedOUs,
 		AllowedDNSs: *serverAllowedDNSs,
 		AllowedIPs:  *serverAllowedIPs,
-		AllowedURIs: *serverAllowedURIs,
+		AllowedURIs: allowedURIs,
 		Logger:      logger,
 	}
 
@@ -578,12 +585,18 @@ func clientBackendDialer(cert certloader.Certificate, network, address, host str
 		config.ServerName = *clientServerName
 	}
 
+	allowedURIs, err := wildcard.CompileList(*clientAllowedURIs)
+	if err != nil {
+		logger.Printf("invalid URI pattern in --verify-uri flag (%s)", err)
+		return nil, err
+	}
+
 	clientACL := auth.ACL{
 		AllowedCNs:  *clientAllowedCNs,
 		AllowedOUs:  *clientAllowedOUs,
 		AllowedDNSs: *clientAllowedDNSs,
 		AllowedIPs:  *clientAllowedIPs,
-		AllowedURIs: *clientAllowedURIs,
+		AllowedURIs: allowedURIs,
 		Logger:      logger,
 	}
 

--- a/wildcard/matcher.go
+++ b/wildcard/matcher.go
@@ -64,13 +64,36 @@ type regexpMatcher struct {
 	pattern *regexp.Regexp
 }
 
-// New creates a new Matcher given a pattern, using '/' as the separator.
-func New(pattern string) (Matcher, error) {
-	return NewWithSeparator(pattern, defaultSeparator)
+// Compile creates a new Matcher given a pattern, using '/' as the separator.
+func Compile(pattern string) (Matcher, error) {
+	return CompileWithSeparator(pattern, defaultSeparator)
 }
 
-// New creates a new Matcher given a pattern and separator rune.
-func NewWithSeparator(pattern string, separator rune) (Matcher, error) {
+// CompileList creates new Matchers given a list patterns, using '/' as the separator.
+func CompileList(patterns []string) ([]Matcher, error) {
+	ms := []Matcher{}
+	for _, pattern := range patterns {
+		m, err := Compile(pattern)
+		if err != nil {
+			return nil, err
+		}
+		ms = append(ms, m)
+	}
+	return ms, nil
+}
+
+// MustCompile creates a new Matcher given a pattern, using '/' as the separator,
+// and panics if the given pattern was invalid.
+func MustCompile(pattern string) Matcher {
+	m, err := CompileWithSeparator(pattern, defaultSeparator)
+	if err != nil {
+		panic(err)
+	}
+	return m
+}
+
+// CompileWithSeparator creates a new Matcher given a pattern and separator rune.
+func CompileWithSeparator(pattern string, separator rune) (Matcher, error) {
 	// Build regular expression from wildcard pattern
 	// - Wildcard '*' should match all chars except forward slash
 	// - Wildcard '**' should match all chars, including forward slash

--- a/wildcard/matcher.go
+++ b/wildcard/matcher.go
@@ -47,6 +47,8 @@ const (
 )
 
 var (
+	errEmptyPattern          = errors.New("input pattern was empty string")
+	errInvalidWildcard       = errors.New("wildcard '*' can only appear between two separators")
 	errInvalidDoubleWildcard = errors.New("wildcard '**' can only appear at end of pattern")
 	errRegexpCompile         = errors.New("unable to compile generated regex (internal bug)")
 )
@@ -74,6 +76,10 @@ func NewWithSeparator(pattern string, separator rune) (Matcher, error) {
 	// - Wildcard '**' should match all chars, including forward slash
 	// All other regex meta chars will need to be quoted
 
+	if pattern == "" {
+		return nil, errEmptyPattern
+	}
+
 	segments := strings.Split(pattern, string(separator))
 
 	var regex bytes.Buffer
@@ -98,6 +104,9 @@ loop:
 			break loop
 		default:
 			// Segment to match literal string
+			if strings.Contains(segment, "*") {
+				return nil, errInvalidWildcard
+			}
 			regex.WriteString(regexp.QuoteMeta(segment))
 		}
 

--- a/wildcard/matcher.go
+++ b/wildcard/matcher.go
@@ -1,0 +1,127 @@
+/*-
+ * Copyright 2018 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package wildcard implements simple wildcard matching meant to be used to
+// match URIs and paths against simple patterns. It's less powerful but also
+// less error-prone than regular expressions.
+//
+// We expose functions to build matchers from simple wildcard patterns.  Each
+// pattern is a sequence of segments separated by a separator, usually a
+// forward slash. Each segment may be a literal string, or a wildcard. We
+// support two types of wildcards, a single '*' wildcard and a double '**'
+// wildcard.
+//
+// A single '*' wildcard will match any literal string that does not contain
+// the separator. It may occur anywhere between two separators in the pattern.
+//
+// A double '**' wildcard will match anything, including the separator rune.
+// It may only occur at the end of a pattern.
+//
+// Furthermore, the matcher will consider the separator optional if it occurs
+// at the end of a string. This means that the paths "foo/bar" and "foo/bar/"
+// are treated as equivalent.
+package wildcard
+
+import (
+	"bytes"
+	"errors"
+	"regexp"
+	"strings"
+)
+
+const (
+	defaultSeparator = '/'
+)
+
+var (
+	errInvalidDoubleWildcard = errors.New("wildcard '**' can only appear at end of pattern")
+	errRegexpCompile         = errors.New("unable to compile generated regex (internal bug)")
+)
+
+// Matcher represents a compiled pattern that can be matched against a string.
+type Matcher interface {
+	// Matches checks if the given input matches the compiled pattern.
+	Matches(string) bool
+}
+
+type regexpMatcher struct {
+	// Compiled regular expression for this matcher
+	pattern *regexp.Regexp
+}
+
+// New creates a new Matcher given a pattern, using '/' as the separator.
+func New(pattern string) (Matcher, error) {
+	return NewWithSeparator(pattern, defaultSeparator)
+}
+
+// New creates a new Matcher given a pattern and separator rune.
+func NewWithSeparator(pattern string, separator rune) (Matcher, error) {
+	// Build regular expression from wildcard pattern
+	// - Wildcard '*' should match all chars except forward slash
+	// - Wildcard '**' should match all chars, including forward slash
+	// All other regex meta chars will need to be quoted
+
+	segments := strings.Split(pattern, string(separator))
+
+	var regex bytes.Buffer
+	regex.WriteString("^")
+
+loop:
+	for i, segment := range segments {
+		switch segment {
+		case "*":
+			// Segment with wildcard
+			regex.WriteString("[^")
+			regex.WriteRune(separator)
+			regex.WriteString("]+")
+		case "**":
+			// Segment with double wildcard
+			// May only appear at the end of a pattern
+			if i != len(segments)-1 {
+				return nil, errInvalidDoubleWildcard
+			}
+			regex.WriteRune('?')
+			regex.WriteString(".*$")
+			break loop
+		default:
+			// Segment to match literal string
+			regex.WriteString(regexp.QuoteMeta(segment))
+		}
+
+		// Separate this segment from next one
+		regex.WriteRune(separator)
+
+		if i == len(segments)-1 {
+			// Final slash should be optional
+			// We want "path" and "path/" to match
+			regex.WriteString("?$")
+		}
+	}
+
+	compiled, err := regexp.Compile(regex.String())
+	if err != nil {
+		return nil, errRegexpCompile
+	}
+
+	return regexpMatcher{
+		pattern: compiled,
+	}, nil
+}
+
+// Matches checks if the given input matches the compiled pattern.
+func (rm regexpMatcher) Matches(input string) bool {
+	return rm.pattern.Match([]byte(input))
+}

--- a/wildcard/matcher_test.go
+++ b/wildcard/matcher_test.go
@@ -224,3 +224,18 @@ func TestMatchingWithMetaChars(t *testing.T) {
 			"invalid",
 		})
 }
+
+func TestInvalidPatterns(t *testing.T) {
+	for _, pattern := range []string{
+		"",
+		"test://foo*/asdf",
+		"test://*foo/asdf",
+		"test://**/asdf",
+		"**://foo/asdf",
+	} {
+		_, err := New(pattern)
+		if err == nil {
+			t.Errorf("should reject invalid pattern '%s'", pattern)
+		}
+	}
+}

--- a/wildcard/matcher_test.go
+++ b/wildcard/matcher_test.go
@@ -1,0 +1,226 @@
+/*-
+ * Copyright 2018 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wildcard
+
+import "testing"
+
+func testMatches(t *testing.T, pattern string, matches []string, invalids []string) {
+	matcher, err := New(pattern)
+	if err != nil {
+		t.Fatalf("bad pattern: '%s' (%s)", pattern, err)
+	}
+
+	t.Logf("testing pattern: '%s' => '%s'", pattern, matcher.(regexpMatcher).pattern.String())
+
+	for _, candidate := range matches {
+		if !matcher.Matches(candidate) {
+			t.Errorf("missed: pattern '%s' didn't match string '%s', but should have", pattern, candidate)
+		}
+	}
+
+	for _, candidate := range invalids {
+		if matcher.Matches(candidate) {
+			t.Errorf("bad match: pattern '%s' matched string '%s', but shouldn't have", pattern, candidate)
+		}
+	}
+}
+
+func TestMatchingSimple(t *testing.T) {
+	testMatches(t,
+		"spiffe://foo/*/bar",
+		[]string{
+			"spiffe://foo/baz/bar",
+			"spiffe://foo/baz/bar/",
+			"spiffe://foo/spam/bar",
+			"spiffe://foo/spam/bar/",
+			"spiffe://foo/asdf/bar",
+			"spiffe://foo/asdf/bar/",
+		},
+		[]string{
+			"invalid",
+			"spiffe://foo/bar",
+			"spiffe://foo//bar",
+			"spiffe://foo/baz/bar/spam",
+			"spiff://foo/asdf/bar",
+			"spiffe://foox/baz/bar",
+			"spiffe://foox/baz/bar/",
+			"spiffe://foox/spam/bar",
+			"spiffe://foox/spam/bar/",
+			"spiffe://foox/asdf/bar",
+			"spiffe://foox/asdf/bar/",
+			"spiffe://foox/baz/barx",
+			"spiffe://foox/baz/barx/",
+			"spiffe://foox/spam/barx",
+			"spiffe://foox/spam/barx/",
+			"spiffe://foox/asdf/barx",
+			"spiffe://foox/asdf/barx/",
+		})
+	testMatches(t,
+		"spiffe://*/*/bar",
+		[]string{
+			"spiffe://foo/baz/bar",
+			"spiffe://foo/baz/bar/",
+			"spiffe://foo/spam/bar",
+			"spiffe://foo/spam/bar/",
+			"spiffe://foo/asdf/bar",
+			"spiffe://foo/asdf/bar/",
+			"spiffe://foox/baz/bar",
+			"spiffe://foox/baz/bar/",
+			"spiffe://foox/spam/bar",
+			"spiffe://foox/spam/bar/",
+			"spiffe://foox/asdf/bar",
+			"spiffe://foox/asdf/bar/",
+		},
+		[]string{
+			"invalid",
+			"spiffe://foo/bar",
+			"spiffe://foo//bar",
+			"spiffe://foo/baz/bar/spam",
+			"spiff://foo/asdf/bar",
+			"spiffe://foox/baz/barx",
+			"spiffe://foox/baz/barx/",
+			"spiffe://foox/spam/barx",
+			"spiffe://foox/spam/barx/",
+			"spiffe://foox/asdf/barx",
+			"spiffe://foox/asdf/barx/",
+		})
+	testMatches(t,
+		"spiffe://foo/*/*",
+		[]string{
+			"spiffe://foo/baz/bar",
+			"spiffe://foo/baz/bar/",
+			"spiffe://foo/spam/bar",
+			"spiffe://foo/spam/bar/",
+			"spiffe://foo/asdf/bar",
+			"spiffe://foo/asdf/bar/",
+			"spiffe://foo/baz/barx",
+			"spiffe://foo/baz/barx/",
+			"spiffe://foo/spam/barx",
+			"spiffe://foo/spam/barx/",
+			"spiffe://foo/asdf/barx",
+			"spiffe://foo/asdf/barx/",
+		},
+		[]string{
+			"invalid",
+			"spiffe://foo/bar",
+			"spiffe://foo//bar",
+			"spiffe://foo/baz/bar/spam",
+			"spiff://foo/asdf/bar",
+		})
+	testMatches(t,
+		"spiffe://*/*/*",
+		[]string{
+			"spiffe://foo/baz/bar",
+			"spiffe://foo/baz/bar/",
+			"spiffe://foo/spam/bar",
+			"spiffe://foo/spam/bar/",
+			"spiffe://foo/asdf/bar",
+			"spiffe://foo/asdf/bar/",
+			"spiffe://foo/baz/barx",
+			"spiffe://foo/baz/barx/",
+			"spiffe://foo/spam/barx",
+			"spiffe://foo/spam/barx/",
+			"spiffe://foo/asdf/barx",
+			"spiffe://foo/asdf/barx/",
+			"spiffe://foox/baz/barx",
+			"spiffe://foox/baz/barx/",
+			"spiffe://foox/spam/barx",
+			"spiffe://foox/spam/barx/",
+			"spiffe://foox/asdf/barx",
+			"spiffe://foox/asdf/barx/",
+		},
+		[]string{
+			"invalid",
+			"spiffe://foo/bar",
+			"spiffe://foo//bar",
+			"spiffe://foo/baz/bar/spam",
+			"spiff://foo/asdf/bar",
+		})
+}
+
+func TestMatchingWithDouble(t *testing.T) {
+	testMatches(t,
+		"spiffe://foo/*/bar/**",
+		[]string{
+			"spiffe://foo/baz/bar",
+			"spiffe://foo/baz/bar/",
+			"spiffe://foo/baz/bar/spam",
+			"spiffe://foo/spam/bar",
+			"spiffe://foo/spam/bar/",
+			"spiffe://foo/spam/bar/asdf",
+			"spiffe://foo/spam/bar/asdf/qwer",
+		},
+		[]string{
+			"invalid",
+			"spiffe://foo/bar",
+			"spiffe://foo//bar",
+			"spiffe://foo//bar/asdf",
+			"spiff://foo/asdf/bar",
+		})
+	testMatches(t,
+		"spiffe://foo/*/bar/**",
+		[]string{
+			"spiffe://foo/baz/bar",
+			"spiffe://foo/baz/bar/",
+			"spiffe://foo/baz/bar/spam",
+			"spiffe://foo/spam/bar",
+			"spiffe://foo/spam/bar/",
+			"spiffe://foo/spam/bar/asdf",
+			"spiffe://foo/spam/bar/asdf/qwer",
+		},
+		[]string{
+			"invalid",
+			"spiffe://foo/bar",
+			"spiffe://foo//bar",
+			"spiffe://foo//bar/asdf",
+			"spiff://foo/asdf/bar",
+		})
+}
+
+func TestMatchingWithMetaChars(t *testing.T) {
+	testMatches(t,
+		// The '.' should not be interpreted as a regex char
+		"spiffe://foo/./bar",
+		[]string{
+			"spiffe://foo/./bar",
+			"spiffe://foo/./bar/",
+		},
+		[]string{
+			"spiffe://foo/x/bar",
+			"spiffe://foo/x/bar/",
+		})
+	testMatches(t,
+		// The '.' should not be interpreted as a regex char
+		"spiffe://././.",
+		[]string{
+			"spiffe://././.",
+			"spiffe://./././",
+		},
+		[]string{
+			"spiffe://a/b/c",
+			"spiffe://a/b/c/",
+		})
+	testMatches(t,
+		// The meta chars should not be interpreted as a regex
+		".+",
+		[]string{
+			".+",
+		},
+		[]string{
+			"invalid",
+		})
+}

--- a/wildcard/matcher_test.go
+++ b/wildcard/matcher_test.go
@@ -19,7 +19,7 @@ package wildcard
 import "testing"
 
 func testMatches(t *testing.T, pattern string, matches []string, invalids []string) {
-	matcher, err := New(pattern)
+	matcher, err := Compile(pattern)
 	if err != nil {
 		t.Fatalf("bad pattern: '%s' (%s)", pattern, err)
 	}
@@ -233,7 +233,7 @@ func TestInvalidPatterns(t *testing.T) {
 		"test://**/asdf",
 		"**://foo/asdf",
 	} {
-		_, err := New(pattern)
+		_, err := Compile(pattern)
 		if err == nil {
 			t.Errorf("should reject invalid pattern '%s'", pattern)
 		}


### PR DESCRIPTION
This implements simple pattern matching so that the `allow-uri` flag can take patterns like:

* `spiffe://a/*/c`
  * matches e.g. `spiffe://a/b/c` or `spiffe://a/b/c/`


* `spiffe://a/b/**`
  * matches e.g. `spiffe://a/b/c` or `spiffe://a/b/c/d/e`

The wildcard `*` matches any char except a forward slash, and can appear between any two slashes. The wildcard `**` can only appear the end of a pattern and will match anything including a slash. The matcher also ignores trailing `/` at the end of a path.