### PR TITLE
Hide allow-ip/verify-ip to avoid confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,10 @@ incoming TLS connections on `localhost:8443` and forwarding them to
 `localhost:8080`. 
 
 To set allowed clients, you must specify at least one of `--allow-all`,
-`--allow-cn`, `--allow-ou`, `--allow-dns-san`, or `--allow-ip-san`. It's
-possible to use these together or to specify them repeatedly to allow multiple
-clients. In this example, we assume that the CN of the client cert we want to
+`--allow-cn`, `--allow-ou`, `--allow-dns` or `--allow-uri`. All checks are made
+against the certificate of the client. Multiple flags are treated as a logical
+disjunction (OR), meaning clients can connect as long as any of the flags
+matches. In this example, we assume that the CN of the client cert we want to
 accept connections from is `client`.
 
 Start a backend server:

--- a/main.go
+++ b/main.go
@@ -70,9 +70,9 @@ var (
 	serverAllowAll       = serverCommand.Flag("allow-all", "Allow all clients, do not check client cert subject.").Bool()
 	serverAllowedCNs     = serverCommand.Flag("allow-cn", "Allow clients with given common name (can be repeated).").PlaceHolder("CN").Strings()
 	serverAllowedOUs     = serverCommand.Flag("allow-ou", "Allow clients with given organizational unit name (can be repeated).").PlaceHolder("OU").Strings()
-	serverAllowedDNSs    = serverCommand.Flag("allow-dns", "Allow clients with given DNS subject alternative name (can be repeated).").PlaceHolder("SAN").Strings()
-	serverAllowedIPs     = serverCommand.Flag("allow-ip", "Allow clients with given IP subject alternative name (can be repeated).").PlaceHolder("SAN").IPList()
-	serverAllowedURIs    = serverCommand.Flag("allow-uri", "Allow clients with given URI subject alternative name (can be repeated).").PlaceHolder("SAN").Strings()
+	serverAllowedDNSs    = serverCommand.Flag("allow-dns", "Allow clients with given DNS subject alternative name (can be repeated).").PlaceHolder("DNS").Strings()
+	serverAllowedIPs     = serverCommand.Flag("allow-ip", "").Hidden().PlaceHolder("SAN").IPList()
+	serverAllowedURIs    = serverCommand.Flag("allow-uri", "Allow clients with given URI subject alternative name (can be repeated).").PlaceHolder("URI").Strings()
 	serverDisableAuth    = serverCommand.Flag("disable-authentication", "Disable client authentication, no client certificate will be required.").Default("false").Bool()
 
 	clientCommand       = app.Command("client", "Client mode (plain TCP/UNIX listener -> TLS target).")
@@ -84,9 +84,9 @@ var (
 	clientConnectProxy   = clientCommand.Flag("connect-proxy", "If set, connect to target over given HTTP CONNECT proxy. Must be HTTP/HTTPS URL.").PlaceHolder("URL").URL()
 	clientAllowedCNs     = clientCommand.Flag("verify-cn", "Allow servers with given common name (can be repeated).").PlaceHolder("CN").Strings()
 	clientAllowedOUs     = clientCommand.Flag("verify-ou", "Allow servers with given organizational unit name (can be repeated).").PlaceHolder("OU").Strings()
-	clientAllowedDNSs    = clientCommand.Flag("verify-dns", "Allow servers with given DNS subject alternative name (can be repeated).").PlaceHolder("SAN").Strings()
-	clientAllowedIPs     = clientCommand.Flag("verify-ip", "Allow servers with given IP subject alternative name (can be repeated).").PlaceHolder("SAN").IPList()
-	clientAllowedURIs    = clientCommand.Flag("verify-uri", "Allow servers with given URI subject alternative name (can be repeated).").PlaceHolder("SAN").Strings()
+	clientAllowedDNSs    = clientCommand.Flag("verify-dns", "Allow servers with given DNS subject alternative name (can be repeated).").PlaceHolder("DNS").Strings()
+	clientAllowedIPs     = clientCommand.Flag("verify-ip", "").Hidden().PlaceHolder("SAN").IPList()
+	clientAllowedURIs    = clientCommand.Flag("verify-uri", "Allow servers with given URI subject alternative name (can be repeated).").PlaceHolder("URI").Strings()
 	clientDisableAuth    = clientCommand.Flag("disable-authentication", "Disable client authentication, no certificate will be provided to the server.").Default("false").Bool()
 
 	// TLS options


### PR DESCRIPTION
Hides the `allow-ip` and `verify-ip` flags, which implement checks on IP subject alternative names on certificates. Hiding these because (1) IPs on certificates are an anti-pattern, and (2) it's kinda confusing that these are checks on the certificate subject and not a network ACL of sorts. Something like `--allow-ip 127.0.0.1` could easily be misinterpreted, for example.