### PR TITLE
Add more wildcard tests

### DIFF
--- a/wildcard/matcher.go
+++ b/wildcard/matcher.go
@@ -125,8 +125,9 @@ loop:
 			if i != len(segments)-1 {
 				return nil, errInvalidDoubleWildcard
 			}
-			regex.WriteRune('?')
-			regex.WriteString(".*$")
+			regex.WriteString("?(|")
+			regex.WriteRune(separator)
+			regex.WriteString(".*)$")
 			break loop
 		default:
 			// Segment to match literal string

--- a/wildcard/matcher.go
+++ b/wildcard/matcher.go
@@ -18,21 +18,24 @@
 // match URIs and paths against simple patterns. It's less powerful but also
 // less error-prone than regular expressions.
 //
-// We expose functions to build matchers from simple wildcard patterns.  Each
+// We expose functions to build matchers from simple wildcard patterns. Each
 // pattern is a sequence of segments separated by a separator, usually a
-// forward slash. Each segment may be a literal string, or a wildcard. We
-// support two types of wildcards, a single '*' wildcard and a double '**'
-// wildcard.
+// forward slash. Each segment in the pattern may be a literal string, or a
+// wildcard. A literal string will be matched exactly, a wildcard will match an
+// arbitrary string.
 //
-// A single '*' wildcard will match any literal string that does not contain
-// the separator. It may occur anywhere between two separators in the pattern.
+// Two types of wildcards are supported:
 //
-// A double '**' wildcard will match anything, including the separator rune.
-// It may only occur at the end of a pattern.
+// (1) A single '*' wildcard will match any literal string that does not
+// contain the separator. It may occur anywhere between two separators in the
+// pattern.
+//
+// (2) A double '**' wildcard will match anything, including the separator
+// rune. It may only occur at the end of a pattern, after a separator.
 //
 // Furthermore, the matcher will consider the separator optional if it occurs
-// at the end of a string. This means that the paths "foo/bar" and "foo/bar/"
-// are treated as equivalent.
+// at the end of a string. This means that, for example, the strings
+// "test://foo/bar" and "test://foo/bar/" are treated as equivalent.
 package wildcard
 
 import (

--- a/wildcard/matcher_test.go
+++ b/wildcard/matcher_test.go
@@ -199,6 +199,7 @@ func TestMatchingWithDouble(t *testing.T) {
 			"spiffe://foo//bar",
 			"spiffe://foo//bar/asdf",
 			"spiff://foo/asdf/bar",
+			"spiffe://foo/baz/barf",
 		})
 	testMatches(t,
 		"spiffe://foo/*/bar/**",
@@ -217,6 +218,7 @@ func TestMatchingWithDouble(t *testing.T) {
 			"spiffe://foo//bar",
 			"spiffe://foo//bar/asdf",
 			"spiff://foo/asdf/bar",
+			"spiffe://foo/baz/barf",
 		})
 }
 

--- a/wildcard/matcher_test.go
+++ b/wildcard/matcher_test.go
@@ -16,7 +16,36 @@
 
 package wildcard
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
+
+func ExampleCompile_simple() {
+	matcher, err := Compile("spiffe://some/*/pattern")
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%t\n", matcher.Matches("spiffe://some/test/pattern"))
+	fmt.Printf("%t\n", matcher.Matches("spiffe://some/test/example"))
+	// Output:
+	// true
+	// false
+}
+
+func ExampleCompile_doubleWildcard() {
+	matcher, err := Compile("spiffe://some/*/pattern/**")
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%t\n", matcher.Matches("spiffe://some/test/pattern"))
+	fmt.Printf("%t\n", matcher.Matches("spiffe://some/test/pattern/that/continues"))
+	// Output:
+	// true
+	// true
+}
 
 func testMatches(t *testing.T, pattern string, matches []string, invalids []string) {
 	matcher, err := Compile(pattern)
@@ -237,5 +266,48 @@ func TestInvalidPatterns(t *testing.T) {
 		if err == nil {
 			t.Errorf("should reject invalid pattern '%s'", pattern)
 		}
+	}
+}
+
+func TestMustCompile(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("call to MustCompile did not panic with invalid pattern")
+		}
+	}()
+
+	// Compile with valid pattern
+	p := MustCompile("test/**")
+	if p == nil {
+		t.Error("MustCompile returned nil with valid pattern?")
+	}
+
+	// Compile with invalid pattern (should panic)
+	MustCompile("**/test")
+}
+
+func TestCompileList(t *testing.T) {
+	// Compile with valid patterns
+	ms, err := CompileList([]string{
+		"test",
+		"test/**",
+	})
+	if err != nil {
+		t.Errorf("CompileList failed with valid patterns: %s", err)
+	}
+	if len(ms) != 2 {
+		t.Errorf("CompileList returned bad number of matchers (%d, wanted 2)", len(ms))
+	}
+
+	// Compile with valid patterns
+	ms, err = CompileList([]string{
+		"test",
+		"**/test",
+	})
+	if err == nil {
+		t.Error("CompileList failed with invalid pattern in input")
+	}
+	if len(ms) != 0 {
+		t.Errorf("CompileList returned bad number of matchers (%d, wanted 0)", len(ms))
 	}
 }


### PR DESCRIPTION
Added more tests, fixed a bug in how `**` behaves (`bar/**` also matched `barf`, instead of just `bar/test`).