### PR TITLE
Add curl into container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN go build -o /usr/bin/ghostunnel github.com/square/ghostunnel
 # Create a multi-stage build with the binary
 FROM alpine
 
-RUN apk add --no-cache --update libtool
+RUN apk add --no-cache --update libtool curl
 COPY --from=build /usr/bin/ghostunnel /usr/bin/ghostunnel
 
 ENTRYPOINT ["/usr/bin/ghostunnel"]


### PR DESCRIPTION
Totally fine to reject this. Having curl in the container makes life simpler for things like running health checks in kubernetes.