### PR TITLE
Add client/server quiet flag to silence TLS errors to log

### DIFF
--- a/main.go
+++ b/main.go
@@ -74,7 +74,6 @@ var (
 	serverAllowedIPs     = serverCommand.Flag("allow-ip", "").Hidden().PlaceHolder("SAN").IPList()
 	serverAllowedURIs    = serverCommand.Flag("allow-uri", "Allow clients with given URI subject alternative name (can be repeated).").PlaceHolder("URI").Strings()
 	serverDisableAuth    = serverCommand.Flag("disable-authentication", "Disable client authentication, no client certificate will be required.").Default("false").Bool()
-	serverQuiet          = serverCommand.Flag("server-quiet", "Silence server logging about inbound TLS errors").Default("false").Bool()
 
 	clientCommand       = app.Command("client", "Client mode (plain TCP/UNIX listener -> TLS target).")
 	clientListenAddress = clientCommand.Flag("listen", "Address and port to listen on (HOST:PORT, or unix:PATH).").PlaceHolder("ADDR").Required().String()
@@ -89,7 +88,6 @@ var (
 	clientAllowedIPs     = clientCommand.Flag("verify-ip", "").Hidden().PlaceHolder("SAN").IPList()
 	clientAllowedURIs    = clientCommand.Flag("verify-uri", "Allow servers with given URI subject alternative name (can be repeated).").PlaceHolder("URI").Strings()
 	clientDisableAuth    = clientCommand.Flag("disable-authentication", "Disable client authentication, no certificate will be provided to the server.").Default("false").Bool()
-	clientQuiet          = clientCommand.Flag("client-quiet", "Silence client logging about TLS errors").Default("false").Bool()
 
 	// TLS options
 	keystorePath        = app.Flag("keystore", "Path to certificate and keystore (PEM with certificate/key, or PKCS12).").PlaceHolder("PATH").String()
@@ -111,6 +109,7 @@ var (
 	// Status & logging
 	statusAddress = app.Flag("status", "Enable serving /_status and /_metrics on given HOST:PORT (or unix:SOCKET).").PlaceHolder("ADDR").String()
 	enableProf    = app.Flag("enable-pprof", "Enable serving /debug/pprof endpoints alongside /_status (for profiling).").Bool()
+	quiet         = app.Flag("quiet", "Silence logging about TLS errors").Default("false").Bool()
 )
 
 func init() {
@@ -436,7 +435,7 @@ func serverListen(context *Context) error {
 		*timeoutDuration,
 		context.dial,
 		logger,
-		*serverQuiet,
+		*quiet,
 	)
 
 	if *statusAddress != "" {
@@ -483,7 +482,7 @@ func clientListen(context *Context) error {
 		*timeoutDuration,
 		context.dial,
 		logger,
-		*clientQuiet,
+		*quiet,
 	)
 
 	if *statusAddress != "" {

--- a/main.go
+++ b/main.go
@@ -74,6 +74,7 @@ var (
 	serverAllowedIPs     = serverCommand.Flag("allow-ip", "").Hidden().PlaceHolder("SAN").IPList()
 	serverAllowedURIs    = serverCommand.Flag("allow-uri", "Allow clients with given URI subject alternative name (can be repeated).").PlaceHolder("URI").Strings()
 	serverDisableAuth    = serverCommand.Flag("disable-authentication", "Disable client authentication, no client certificate will be required.").Default("false").Bool()
+	serverQuiet          = serverCommand.Flag("server-quiet", "Silence server logging about inbound TLS errors").Default("false").Bool()
 
 	clientCommand       = app.Command("client", "Client mode (plain TCP/UNIX listener -> TLS target).")
 	clientListenAddress = clientCommand.Flag("listen", "Address and port to listen on (HOST:PORT, or unix:PATH).").PlaceHolder("ADDR").Required().String()
@@ -88,6 +89,7 @@ var (
 	clientAllowedIPs     = clientCommand.Flag("verify-ip", "").Hidden().PlaceHolder("SAN").IPList()
 	clientAllowedURIs    = clientCommand.Flag("verify-uri", "Allow servers with given URI subject alternative name (can be repeated).").PlaceHolder("URI").Strings()
 	clientDisableAuth    = clientCommand.Flag("disable-authentication", "Disable client authentication, no certificate will be provided to the server.").Default("false").Bool()
+	clientQuiet          = clientCommand.Flag("client-quiet", "Silence client logging about TLS errors").Default("false").Bool()
 
 	// TLS options
 	keystorePath        = app.Flag("keystore", "Path to certificate and keystore (PEM with certificate/key, or PKCS12).").PlaceHolder("PATH").String()
@@ -434,6 +436,7 @@ func serverListen(context *Context) error {
 		*timeoutDuration,
 		context.dial,
 		logger,
+		*serverQuiet,
 	)
 
 	if *statusAddress != "" {
@@ -480,6 +483,7 @@ func clientListen(context *Context) error {
 		*timeoutDuration,
 		context.dial,
 		logger,
+		*clientQuiet,
 	)
 
 	if *statusAddress != "" {

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -39,7 +39,7 @@ func TestMultipleShutdownCalls(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	assert.Nil(t, err, "should be able to listen on random port")
 
-	p := New(ln, 60*time.Second, nil, &testLogger{})
+	p := New(ln, 60*time.Second, nil, &testLogger{}, false)
 
 	// Should not panic
 	p.Shutdown()
@@ -62,7 +62,7 @@ func TestProxySuccess(t *testing.T) {
 	}
 
 	// Start accept loop
-	p := New(incoming, 60*time.Second, dialer, &testLogger{})
+	p := New(incoming, 60*time.Second, dialer, &testLogger{}, false)
 	go p.Accept()
 	defer p.Shutdown()
 
@@ -104,7 +104,7 @@ func TestBackendDialError(t *testing.T) {
 		return nil, errors.New("failure for test")
 	}
 
-	p := New(ln, 60*time.Second, dialer, &testLogger{})
+	p := New(ln, 60*time.Second, dialer, &testLogger{}, false)
 	go p.Accept()
 	defer p.Shutdown()
 


### PR DESCRIPTION
In a dynamic environment like Kubernetes, health checks
are often performed via simple TCP connections. These in
turn never complete the TLS handshake and cause a lot of
ongoing noisy errors. Allow these to be silenced.

Signed-off-by: Don Bowman <don@agilicus.com>