### PR TITLE
Generate man page for new releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ deploy:
       - dist/ghostunnel-${TRAVIS_TAG}-darwin-amd64-with-pkcs11
       - dist/ghostunnel-${TRAVIS_TAG}-windows-386-with-pkcs11.exe
       - dist/ghostunnel-${TRAVIS_TAG}-windows-amd64-with-pkcs11.exe
+      - dist/ghostunnel-${TRAVIS_TAG}.man
     draft: true
     skip_cleanup: true
     on:

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ VERSION := $(shell git describe --always --dirty)
 ghostunnel: $(SOURCE_FILES)
 	go build -ldflags '-X main.version=${VERSION}' -o ghostunnel .
 
+# Man page
+ghostunnel.man: ghostunnel
+	./ghostunnel --help-man > $@
+
 # Test binary with coverage instrumentation
 ghostunnel.test: $(SOURCE_FILES)
 	go test -c -covermode=count -coverpkg .,./auth,./certloader,./proxy,./wildcard

--- a/Makefile.dist
+++ b/Makefile.dist
@@ -57,5 +57,7 @@ $(foreach goarch,$(XC_ARCH),$(foreach goos,$(XC_OS),$(eval $(call make-xc-target
 dist:
 	@rm -rf "${CURRENT_DIR}/dist/"
 	@mkdir -p "${CURRENT_DIR}/dist/"
+	@$(MAKE) -f Makefile ghostunnel.man
+	@mv ghostunnel.man "${CURRENT_DIR}/dist/ghostunnel-${VERSION}.man"
 	@$(MAKE) -f "${MKFILE_PATH}" -j1 build
 .PHONY: dist


### PR DESCRIPTION
Generates a man page when running a dist build using the `--help-man` functionality in Kingpin, and makes it so it gets uploaded to GitHub when we do a release. 