### PR TITLE
Don't set VerifyPeerCertificate function if authentication is disabled

### DIFF
--- a/main.go
+++ b/main.go
@@ -442,9 +442,10 @@ func serverListen(context *Context) error {
 	}
 
 	config.GetCertificate = context.cert.GetCertificate
-	config.VerifyPeerCertificate = serverACL.VerifyPeerCertificateServer
 	if *serverDisableAuth {
 		config.ClientAuth = tls.NoClientCert
+	} else {
+		config.VerifyPeerCertificate = serverACL.VerifyPeerCertificateServer
 	}
 
 	listener, err := reuseport.NewReusablePortListener("tcp", (*serverListenAddress).String())

--- a/tests/test-server-disable-authentication.py
+++ b/tests/test-server-disable-authentication.py
@@ -29,13 +29,23 @@ if __name__ == "__main__":
                                      '--cacert=root.crt',
                                      '--disable-authentication'])
 
-        # connect with client1, confirm that the tunnel is up
+        # connect with no client cert, confirm that the tunnel is up
         pair = SocketPair(TlsClient(None, 'root', 13001), TcpServer(13002))
         pair.validate_can_send_from_client(
             "hello world", "1: client -> server")
         pair.validate_can_send_from_server(
             "hello world", "1: server -> client")
         pair.validate_closing_client_closes_server(
+            "1: client closed -> server closed")
+
+        # connect with client1 cert, confirm that the tunnel is up
+        pair2 = SocketPair(
+            TlsClient('client1', 'root', 13001), TcpServer(13002))
+        pair2.validate_can_send_from_client(
+            "hello world", "1: client -> server")
+        pair2.validate_can_send_from_server(
+            "hello world", "1: server -> client")
+        pair2.validate_closing_client_closes_server(
             "1: client closed -> server closed")
 
         # connect with client2, confirm that the tunnel isn't up


### PR DESCRIPTION
Fixes #221

The TLS config property `VerifyPeerCertificate` was still being set even if the `disable-authentication` flag was set. This caused an error to be returned from the function if a client presented a client cert, as none of the verification would pass. Therefore, it was agreed in #221 that this shouldn't be configured if authentication is disabled.

### Note:
It seems that the `serverListen` function in main.go isn't covered by tests and thus nor is this code path. I'd be happy to add a test for this if you point me in the right direction. 