### PR TITLE
Add a "nopkcs11" build tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ before_install:
 install:
   # Compile with CGO on/off for testing
   - CGO_ENABLED=0 go build -o ghostunnel-${TRAVIS_TAG}-linux-amd64-without-pkcs11 .
+  - CGO_ENABLED=1 go build -tags nopkcs11 -o ghostunnel-${TRAVIS_TAG}-linux-amd64-without-pkcs11-but-with-cgo .
   - CGO_ENABLED=1 go build -o ghostunnel-${TRAVIS_TAG}-linux-amd64-with-pkcs11 .
   # Build Docker container
   - make docker-build

--- a/certloader/pkcs11_disabled.go
+++ b/certloader/pkcs11_disabled.go
@@ -1,4 +1,4 @@
-// +build !cgo
+// +build !cgo nopkcs11
 
 /*-
  * Copyright 2018 Square Inc.

--- a/certloader/pkcs11_enabled.go
+++ b/certloader/pkcs11_enabled.go
@@ -1,4 +1,4 @@
-// +build cgo
+// +build cgo,!nopkcs11
 
 /*-
  * Copyright 2018 Square Inc.


### PR DESCRIPTION
This allows opting out of PKCS11 (to avoid needing libltdl), but with CGO still
enabled so certstore is usable

It's a negative so that PKCS11 is built by default.  Maybe we don't need PKCS11 by default, and can make it a build time option like certstore?

~ CGO_ENABLED=1 go build -tags "nopkcs11 certstore"
~ otool -L ./ghostunnel
./ghostunnel:
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1570.15.0)
	/System/Library/Frameworks/Security.framework/Versions/A/Security (compatibility version 1.0.0, current version 58286.251.4)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.250.1)