### PR TITLE
Support for launchd and improvements for keychain/certstore certificate selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 ghostunnel
 ghostunnel.exe
 ghostunnel.test
+ghostunnel.certstore
 ghostunnel-*
 __pycache__
 dist/

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ VERSION := $(shell git describe --always --dirty)
 ghostunnel: $(SOURCE_FILES)
 	go build -ldflags '-X main.version=${VERSION}' -o ghostunnel .
 
+# Ghostunnel binary with certstore enabled
+ghostunnel.certstore: $(SOURCE_FILES)
+	go build -tags certstore -ldflags '-X main.version=${VERSION}' -o ghostunnel.certstore .
+
 # Man page
 ghostunnel.man: ghostunnel
 	./ghostunnel --help-custom-man > $@

--- a/launchd_disabled.go
+++ b/launchd_disabled.go
@@ -1,0 +1,12 @@
+// +build !darwin
+
+package main
+
+import (
+	"errors"
+	"net"
+)
+
+func LaunchdSocket() (net.Listener, error) {
+	return nil, errors.New("launchd is only supported on darwin")
+}

--- a/launchd_enabled.go
+++ b/launchd_enabled.go
@@ -1,0 +1,39 @@
+// +build darwin
+
+package main
+
+/*
+#include <stdlib.h>
+int launch_activate_socket(const char *name, int **fds, size_t *cnt);
+*/
+import "C"
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"unsafe"
+)
+
+func LaunchdSocket() (net.Listener, error) {
+	c_name := C.CString("Listeners")
+	var c_fds *C.int
+	c_cnt := C.size_t(0)
+
+	err := C.launch_activate_socket(c_name, &c_fds, &c_cnt)
+	if err != 0 {
+		return nil, fmt.Errorf("couldn't activate launchd socket: %v", err)
+	}
+
+	length := int(c_cnt)
+	if length != 1 {
+		return nil, fmt.Errorf("expected exactly 1 listening socket configured in launchd, found %d", length)
+	}
+	pointer := unsafe.Pointer(c_fds)
+	fds := (*[1]C.int)(pointer)
+
+	file := os.NewFile(uintptr(fds[0]), "")
+
+	C.free(pointer)
+	return net.FileListener(file)
+}


### PR DESCRIPTION
This PR introduces two new features.

1. When starting ghostunnel under launchd, it's possible to have launchd provide a socket that ghostunnel can use. This behavior is provided now in launchd_enabled.go.
2. There are some corner cases with selecting a certificate that were not previously supported. These are detailed in the commit message on the third commit.