### PR TITLE
Allow cert/key in client mode, fixes issue #230

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -243,7 +243,21 @@ func TestClientFlagValidation(t *testing.T) {
 	*clientDisableAuth = true
 	err = clientValidateFlags()
 	assert.NotNil(t, err, "--keystore can't be used with --disable-authentication")
+
+	*keystorePath = ""
+	*certPath = "file"
+	*keyPath = "file"
+	err = clientValidateFlags()
+	assert.NotNil(t, err, "--cert/--key can't be used with --disable-authentication")
+
+	*keystorePath = "file"
+	*certPath = "file"
+	*keyPath = "file"
 	*clientDisableAuth = false
+	err = clientValidateFlags()
+	assert.NotNil(t, err, "--keystore can't be used with --cert/--key")
+	*certPath = ""
+	*keyPath = ""
 
 	test := "test"
 	keychainIdentity = &test

--- a/tests/common.py
+++ b/tests/common.py
@@ -43,7 +43,7 @@ def run_ghostunnel(args, stdout=sys.stdout.buffer, stderr=sys.stderr.buffer, pre
     return Popen(cmd, stdout=stdout, stderr=stderr)
 
 def assert_not_zero(ghostunnel):
-    ret = ghostunnel.wait(timeout=20)
+    ret = ghostunnel.wait(timeout=5)
     if ret == 0:
         raise Exception(
             'ghostunnel terminated with zero, but expected otherwise')

--- a/tests/common.py
+++ b/tests/common.py
@@ -42,6 +42,14 @@ def run_ghostunnel(args, stdout=sys.stdout.buffer, stderr=sys.stderr.buffer, pre
 
     return Popen(cmd, stdout=stdout, stderr=stderr)
 
+def assert_not_zero(ghostunnel):
+    ret = ghostunnel.wait(timeout=20)
+    if ret == 0:
+        raise Exception(
+            'ghostunnel terminated with zero, but expected otherwise')
+    else:
+        print_ok("OK (terminated)")
+
 def terminate(ghostunnel):
     """Gracefully terminate ghostunnel (with timeout)"""
     print_ok("terminating ghostunnel instance")

--- a/tests/test-client-handles-client-closes-connection-unix.py
+++ b/tests/test-client-handles-client-closes-connection-unix.py
@@ -19,7 +19,8 @@ if __name__ == "__main__":
         ghostunnel = run_ghostunnel(['client',
                                      '--listen=unix:{0}'.format(client.get_socket_path()),
                                      '--target={0}:13002'.format(LOCALHOST),
-                                     '--keystore=client.p12',
+                                     '--cert=client.crt',
+                                     '--key=client.key',
                                      '--status={0}:{1}'.format(LOCALHOST,
                                                                STATUS_PORT),
                                      '--cacert=root.crt'])

--- a/tests/test-mutually-exclusive-client-flags.py
+++ b/tests/test-mutually-exclusive-client-flags.py
@@ -10,39 +10,48 @@ if __name__ == "__main__":
         root.create_signed_cert('server')
 
         # start ghostunnel with bad flags
-        ghostunnel1 = run_ghostunnel(['server',
+        ghostunnel1 = run_ghostunnel(['client',
                                       '--listen={0}:13001'.format(LOCALHOST),
                                       '--target={0}:13002'.format(LOCALHOST),
                                       '--keystore=server.p12',
                                       '--disable-authentication',
-                                      '--allow-cn=test.example.com',
                                       '--cacert=root.crt'])
         assert_not_zero(ghostunnel1)
 
-        ghostunnel2 = run_ghostunnel(['server',
+        ghostunnel2 = run_ghostunnel(['client',
                                       '--listen={0}:13001'.format(LOCALHOST),
                                       '--target={0}:13002'.format(LOCALHOST),
-                                      '--keystore=server.p12',
                                       '--cert=server.crt',
                                       '--key=server.key',
+                                      '--disable-authentication',
                                       '--cacert=root.crt'])
         assert_not_zero(ghostunnel2)
 
-        ghostunnel3 = run_ghostunnel(['server',
-                                      '--listen={0}:13001'.format(LOCALHOST),
-                                      '--target={0}:13002'.format(LOCALHOST),
-                                      '--cert=server.crt',
-                                      '--cacert=root.crt'])
-        assert_not_zero(ghostunnel3)
-
-        ghostunnel4 = run_ghostunnel(['server',
+        ghostunnel3 = run_ghostunnel(['client',
                                       '--listen={0}:13001'.format(LOCALHOST),
                                       '--target={0}:13002'.format(LOCALHOST),
                                       '--key=server.crt',
                                       '--cacert=root.crt'])
+        assert_not_zero(ghostunnel3)
+
+        ghostunnel4 = run_ghostunnel(['client',
+                                      '--listen={0}:13001'.format(LOCALHOST),
+                                      '--target={0}:13002'.format(LOCALHOST),
+                                      '--disable-authentication',
+                                      '--key=server.key',
+                                      '--cacert=root.crt'])
         assert_not_zero(ghostunnel4)
+
+        ghostunnel5 = run_ghostunnel(['client',
+                                      '--listen={0}:13001'.format(LOCALHOST),
+                                      '--target={0}:13002'.format(LOCALHOST),
+                                      '--disable-authentication',
+                                      '--cert=server.key',
+                                      '--cacert=root.crt'])
+        assert_not_zero(ghostunnel5)
     finally:
         terminate(ghostunnel1)
         terminate(ghostunnel2)
         terminate(ghostunnel3)
         terminate(ghostunnel4)
+        terminate(ghostunnel5)


### PR DESCRIPTION
Flag validation previously blocked using cert/key in client mode, fix that up and add some more tests for flag validation handling.