### PR TITLE
Add alternative url for prometheus metrics

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -33,7 +33,7 @@ How to check status and read connection metrics:
     curl --cacert test-keys/cacert.pem 'https://localhost:6060/_metrics?format=json'
     
     # Metrics information (Prometheus)
-    curl --cacert test-keys/cacert.pem 'https://localhost:6060/_metrics?format=prometheus'
+    curl --cacert test-keys/cacert.pem 'https://localhost:6060/_metrics/prometheus'
 
 How to use profiling endpoints, if `--enable-pprof` is set:
 

--- a/main.go
+++ b/main.go
@@ -573,6 +573,9 @@ func (context *Context) serveStatus() error {
 
 	mux := http.NewServeMux()
 	mux.Handle("/_status", context.status)
+	mux.HandleFunc("/_metrics/prometheus", func(w http.ResponseWriter, r *http.Request) {
+		promHandler.ServeHTTP(w, r)
+	})
 	mux.HandleFunc("/_metrics", func(w http.ResponseWriter, r *http.Request) {
 		params := r.URL.Query()
 		format, ok := params["format"]


### PR DESCRIPTION
Add `/_metrics/prometheus` metrics url to make it easier to get it working in Kubernetes using Proemtheus annotations.