### PR TITLE
Switch to distroless docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,13 +18,12 @@ COPY . /go/src/github.com/square/ghostunnel
 
 # Build
 RUN cd /go/src/github.com/square/ghostunnel && \
-    GO111MODULE=on make clean ghostunnel && \
+    CGO_ENABLED=0 GOOS=linux GO111MODULE=on make clean ghostunnel && \
     cp ghostunnel /usr/bin/ghostunnel
 
 # Create a multi-stage build with the binary
-FROM alpine
+FROM gcr.io/distroless/static
 
-RUN apk add --no-cache --update libtool curl
-COPY --from=build /usr/bin/ghostunnel /usr/bin/ghostunnel
+COPY --from=build /usr/bin/ghostunnel /ghostunnel
 
-ENTRYPOINT ["/usr/bin/ghostunnel"]
+ENTRYPOINT ["/ghostunnel"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,6 @@ RUN cd /go/src/github.com/square/ghostunnel && \
 # Create a multi-stage build with the binary
 FROM gcr.io/distroless/static
 
-COPY --from=build /usr/bin/ghostunnel /ghostunnel
+COPY --from=build /usr/bin/ghostunnel /usr/bin/ghostunnel
 
-ENTRYPOINT ["/ghostunnel"]
+ENTRYPOINT ["/usr/bin/ghostunnel"]

--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,11 @@ VERSION := $(shell git describe --always --dirty)
 
 # Ghostunnel binary
 ghostunnel: $(SOURCE_FILES)
-	go build -ldflags '-X main.version=${VERSION}' -o ghostunnel .
+	go build -ldflags '-extldflags "-static" -X main.version=${VERSION}' -o ghostunnel .
 
 # Ghostunnel binary with certstore enabled
 ghostunnel.certstore: $(SOURCE_FILES)
-	go build -tags certstore -ldflags '-X main.version=${VERSION}' -o ghostunnel.certstore .
+	go build -tags certstore -ldflags '-extldflags "-static" -X main.version=${VERSION}' -o ghostunnel.certstore .
 
 # Man page
 ghostunnel.man: ghostunnel


### PR DESCRIPTION
Switch to google's distroless docker images (see https://github.com/GoogleContainerTools/distroless ) where no other binaries or libraries are installed. Root CA certificates are still installed (in `/etc/ssl/certs/ca-certificates.crt`) and `/etc/` is still maintained by the distroless image.

This moves also the binary from `/usr/bin/ghostunnel` to `/ghostunnel`.

Alpine image: 28.5MB
Distroless image: 16.9MB