### PR TITLE
Correctly set Content-Type for /_status response

### DIFF
--- a/status.go
+++ b/status.go
@@ -111,6 +111,7 @@ func (s *statusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	out, err := json.Marshal(resp)
 	panicOnError(err)
 
+	w.Header().Set("Content-Type", "application/json")
 	if !resp.Ok {
 		w.WriteHeader(http.StatusServiceUnavailable)
 	}

--- a/status_test.go
+++ b/status_test.go
@@ -69,6 +69,10 @@ func TestStatusHandlerNew(t *testing.T) {
 	if response.Code != 503 {
 		t.Error("status should return 503 if not yet listening")
 	}
+
+	if response.Header().Get("Content-Type") != "application/json" {
+		t.Error("status response should be application/json")
+	}
 }
 
 func TestStatusHandlerListening(t *testing.T) {
@@ -79,6 +83,10 @@ func TestStatusHandlerListening(t *testing.T) {
 
 	if response.Code != 200 {
 		t.Error("status should return 200 once listening")
+	}
+
+	if response.Header().Get("Content-Type") != "application/json" {
+		t.Error("status response should be application/json")
 	}
 }
 


### PR DESCRIPTION
Without this change, `_/status` returns a JSON response with Content-Type set to `text/plain; charset=utf-8`