### PR TITLE
Fix issue #234

### DIFF
--- a/certloader/no_cert.go
+++ b/certloader/no_cert.go
@@ -55,12 +55,12 @@ func (c *trustBundle) Reload() error {
 
 // GetCertificate retrieves the actual underlying tls.Certificate.
 func (c *trustBundle) GetCertificate(clientHello *tls.ClientHelloInfo) (*tls.Certificate, error) {
-	return nil, nil
+	return new(tls.Certificate), nil
 }
 
 // GetClientCertificate retrieves the actual underlying tls.Certificate.
 func (c *trustBundle) GetClientCertificate(certInfo *tls.CertificateRequestInfo) (*tls.Certificate, error) {
-	return nil, nil
+	return new(tls.Certificate), nil
 }
 
 // GetTrustStore returns the most up-to-date version of the trust store / CA bundle.

--- a/certloader/no_cert_test.go
+++ b/certloader/no_cert_test.go
@@ -36,10 +36,10 @@ func TestNoCertificate(t *testing.T) {
 	assert.Nil(t, err, "should read valid bundle")
 
 	c, err := cert.GetCertificate(nil)
-	assert.Nil(t, c, "should have nil server cert")
+	assert.NotNil(t, c, "should have non-nil server cert")
 
 	c, err = cert.GetClientCertificate(nil)
-	assert.Nil(t, c, "should have nil client cert")
+	assert.NotNil(t, c, "should have non-nil client cert")
 }
 
 func TestNoCertificateInvalid(t *testing.T) {


### PR DESCRIPTION
GetCertificate and GetClientCertificate should always return a non-nil cert, if no cert is present an empty tls.Certificate should be used. Otherwise crypto/x509 may panic with a nil ptr deref in a TLS handshake. See #234. cc @mblaschke 