### PR TITLE
test-keys: fix order of prerequisites in rules

### DIFF
--- a/test-keys/Makefile
+++ b/test-keys/Makefile
@@ -8,16 +8,21 @@ all: root-combined.pem root-key.pem server-combined.pem server-keystore.p12 clie
 %-csr.pem: %-key.pem
 	openssl req -new -key $< -out $@ -subj /CN=$(@:-csr.pem=)
 
-root-cert.pem: openssl.ext root-csr.pem root-key.pem
+##
+## NOTE: At the following rules, CSR should be the 1st, and key/certificate/CA
+##       the 2nd prerequisite
+##
+
+root-cert.pem: root-csr.pem root-key.pem openssl.ext
 	openssl x509 -req -sha256 -in $< -signkey $(word 2,$^) -out $@ -days 5000 -extfile openssl.ext -extensions root
 
 cacert.pem: root-cert.pem
 	cp $< $@
 
-server-cert.pem: openssl.ext server-csr.pem root-combined.pem
+server-cert.pem: server-csr.pem root-combined.pem openssl.ext
 	openssl x509 -req -sha256 -in $< -CA $(word 2,$^) -CAkey $(word 2,$^) -CAcreateserial -out $@ -days 5000 -extfile openssl.ext -extensions server
 
-client-cert.pem: openssl.ext client-csr.pem root-combined.pem
+client-cert.pem: client-csr.pem root-combined.pem openssl.ext
 	openssl x509 -req -sha256 -in $< -CA $(word 2,$^) -CAkey $(word 2,$^) -CAcreateserial -out $@ -days 5000 -extfile openssl.ext -extensions client
 
 # Combined certificate/key file


### PR DESCRIPTION
The change introduced in the commit `396aebe83bf353e2f` broke the build
rules in the recipes, as the latter depend heavily, but not explicitly,
in the order of the prerequisites.  Thus, it is very easy for someone to
break these rules.

To make the order more explicit, I added a short notice.  Ideally, we
should not depend on such order or let make(1) figure out automatically
the correct elements.