### PR TITLE
Add subject to connect log

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -283,17 +283,11 @@ func isClosedConnectionError(err error) bool {
 func peerCertificatesString(conn net.Conn) string {
 	if tlsConn, ok := conn.(*tls.Conn); ok {
 		if len(tlsConn.ConnectionState().PeerCertificates) > 0 {
-			subjects := make([]string, len(tlsConn.ConnectionState().PeerCertificates))
-
-			for i, p := range tlsConn.ConnectionState().PeerCertificates {
-				subjects[i] = p.Subject.String()
-			}
-
-			return strings.Join(subjects, "/")
+			return tlsConn.ConnectionState().PeerCertificates[0].Subject.String()
 		}
 
-		return "No Peer Certificate"
+		return "no peer certificate"
 	}
 
-	return "No TLS"
+	return "no tls"
 }


### PR DESCRIPTION
We are starting to use ghostunnel for a project and we require to store an audit log (on the server) matching the subject of the certificate and the IP of the client.
The easy way is just to add it to the already existing connection log and parsing ghostunnel output.

I'm PRing it in case you find it useful/interesting.