### PR TITLE
Enable serving /_status and /_metrics via HTTP

### DIFF
--- a/main.go
+++ b/main.go
@@ -615,13 +615,9 @@ func (context *Context) serveStatus() error {
 		mux.Handle("/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
 	}
 
-	serveHTTPS := true
-	if strings.HasPrefix(*statusAddress, "http://") {
-		*statusAddress = (*statusAddress)[7:]
-		serveHTTPS = false
-	}
+	https, addr := socket.ParseHTTPAddress(*statusAddress)
 
-	network, address, _, err := socket.ParseAddress(*statusAddress)
+	network, address, _, err := socket.ParseAddress(addr)
 	if err != nil {
 		return err
 	}
@@ -632,7 +628,7 @@ func (context *Context) serveStatus() error {
 		return err
 	}
 
-	if network != "unix" && serveHTTPS && context.tlsConfigSource.CanServe() {
+	if network != "unix" && https && context.tlsConfigSource.CanServe() {
 		config, err := buildServerConfig(*enabledCipherSuites)
 		if err != nil {
 			return err

--- a/main.go
+++ b/main.go
@@ -615,6 +615,12 @@ func (context *Context) serveStatus() error {
 		mux.Handle("/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
 	}
 
+	serveHTTPS := true
+	if strings.HasPrefix(*statusAddress, "http://") {
+		*statusAddress = (*statusAddress)[7:]
+		serveHTTPS = false
+	}
+
 	network, address, _, err := socket.ParseAddress(*statusAddress)
 	if err != nil {
 		return err
@@ -626,7 +632,7 @@ func (context *Context) serveStatus() error {
 		return err
 	}
 
-	if network != "unix" && context.tlsConfigSource.CanServe() {
+	if network != "unix" && serveHTTPS && context.tlsConfigSource.CanServe() {
 		config, err := buildServerConfig(*enabledCipherSuites)
 		if err != nil {
 			return err

--- a/socket/net.go
+++ b/socket/net.go
@@ -62,6 +62,24 @@ func ParseAddress(input string) (network, address, host string, err error) {
 	return
 }
 
+// ParseHTTPAddress parses a string representing a TCP address or HTTP/HTTPS address
+// If the input is HTTP/HTTPS, return address will strip away the prefix
+// Otherwise, return address will be same as input
+// https is default to be true, unless http:// prefix is found
+func ParseHTTPAddress(input string) (https bool, address string) {
+	if strings.HasPrefix(input, "http://") {
+		https = false
+		address = input[7:]
+		return
+	} else if strings.HasPrefix(input, "https://") {
+		https = true
+		address = input[8:]
+		return
+	}
+
+	return true, input
+}
+
 // Open a listening socket with the given network and address.
 // Supports 'unix', 'tcp', 'launchd' and 'systemd' as the network.
 //

--- a/socket/net_test.go
+++ b/socket/net_test.go
@@ -79,3 +79,29 @@ func TestParseAddress(t *testing.T) {
 	_, _, _, err = ParseAddress("systemdfoobar")
 	assert.NotNil(t, err, "was able to parse invalid host/port")
 }
+
+func TestParseHTTPAddress(t *testing.T) {
+	https, address := ParseHTTPAddress("http://localhost")
+	if https != false {
+		t.Errorf("unexpected https: %t", https)
+	}
+	if address != "localhost" {
+		t.Errorf("unexpected address: %s", address)
+	}
+
+	https, address = ParseHTTPAddress("https://localhost")
+	if https != true {
+		t.Errorf("unexpected https: %t", https)
+	}
+	if address != "localhost" {
+		t.Errorf("unexpected address: %s", address)
+	}
+
+	https, address = ParseHTTPAddress("127.0.0.1:8000")
+	if https != true {
+		t.Errorf("unexpected https: %t", https)
+	}
+	if address != "127.0.0.1:8000" {
+		t.Errorf("unexpected address: %s", address)
+	}
+}


### PR DESCRIPTION
The pull request is to address the issue https://github.com/square/ghostunnel/issues/294

By making parameter `--status` handle value like `http://127.0.0.1:8888`, `/_status` and `/_metrics` could serve via HTTP.

